### PR TITLE
Simplify dictionary extraction

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,56 +52,6 @@
 				<plugins>
 					<plugin>
 						<groupId>org.apache.maven.plugins</groupId>
-						<artifactId>maven-dependency-plugin</artifactId>
-						<version>3.0.2</version>
-						<executions>
-							<execution>
-								<id>unpack-system-dic</id>
-								<phase>generate-test-resources</phase>
-								<goals>
-									<goal>unpack</goal>
-								</goals>
-								<configuration>
-									<artifactItems>
-										<artifactItem>
-											<groupId>com.worksap.nlp</groupId>
-											<artifactId>sudachi</artifactId>
-											<classifier>executable</classifier>
-											<version>${sudachi.version}</version>
-											<type>zip</type>
-											<outputDirectory>${project.build.directory}/sudachi-executable</outputDirectory>
-											<includes>**/system.dic</includes>
-										</artifactItem>
-									</artifactItems>
-								</configuration>
-							</execution>
-						</executions>
-					</plugin>
-					<plugin>
-						<artifactId>maven-antrun-plugin</artifactId>
-						<version>1.8</version>
-						<executions>
-							<execution>
-							<phase>generate-test-resources</phase>
-								<goals>
-									<goal>run</goal>
-								</goals>
-								<configuration>
-									<target>
-										<copy
-											todir="src/test/resources/com/worksap/nlp/lucene/sudachi/ja"
-											flatten="true">
-											<fileset dir="${project.build.directory}/sudachi-executable/">
-												<include name="**/system.dic" />
-											</fileset>
-										</copy>
-									</target>
-								</configuration>
-							</execution>
-						</executions>
-					</plugin>
-					<plugin>
-						<groupId>org.apache.maven.plugins</groupId>
 						<artifactId>maven-javadoc-plugin</artifactId>
 						<version>3.0.0-M1</version>
 						<executions>
@@ -213,6 +163,33 @@
 						</fileset>
 					</filesets>
 				</configuration>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-dependency-plugin</artifactId>
+				<version>3.0.2</version>
+				<executions>
+					<execution>
+						<id>unpack-system-dic</id>
+						<phase>generate-test-resources</phase>
+						<goals>
+							<goal>unpack</goal>
+						</goals>
+						<configuration>
+							<artifactItems>
+								<artifactItem>
+									<groupId>com.worksap.nlp</groupId>
+									<artifactId>sudachi</artifactId>
+									<classifier>dictionary</classifier>
+									<version>${sudachi.version}</version>
+									<type>zip</type>
+									<outputDirectory>src/test/resources/com/worksap/nlp/lucene/sudachi/ja</outputDirectory>
+									<includes>system.dic</includes>
+								</artifactItem>
+							</artifactItems>
+						</configuration>
+					</execution>
+				</executions>
 			</plugin>
 			<plugin>
 				<groupId>org.sonarsource.scanner.maven</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -42,44 +42,6 @@
 	</repositories>
 	<profiles>
 		<profile>
-			<id>extract-system-dic</id>
-			<activation>
-				<file>
-					<missing>src/test/resources/com/worksap/nlp/lucene/sudachi/ja/system.dic</missing>
-				</file>
-			</activation>
-			<build>
-				<plugins>
-					<plugin>
-						<groupId>org.apache.maven.plugins</groupId>
-						<artifactId>maven-javadoc-plugin</artifactId>
-						<version>3.0.0-M1</version>
-						<executions>
-							<execution>
-								<id>attach-javadocs</id>
-								<goals>
-									<goal>jar</goal>
-								</goals>
-							</execution>
-						</executions>
-					</plugin>
-					<plugin>
-						<groupId>org.apache.maven.plugins</groupId>
-						<artifactId>maven-source-plugin</artifactId>
-						<version>2.2.1</version>
-						<executions>
-							<execution>
-								<id>attach-sources</id>
-								<goals>
-									<goal>jar-no-fork</goal>
-								</goals>
-							</execution>
-						</executions>
-					</plugin>
-				</plugins>
-			</build>
-		</profile>
-		<profile>
 			<id>pre-merge</id>
 			<activation>
 				<property>
@@ -188,6 +150,32 @@
 								</artifactItem>
 							</artifactItems>
 						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-javadoc-plugin</artifactId>
+				<version>3.0.0-M1</version>
+				<executions>
+					<execution>
+						<id>attach-javadocs</id>
+						<goals>
+							<goal>jar</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-source-plugin</artifactId>
+				<version>2.2.1</version>
+				<executions>
+					<execution>
+						<id>attach-sources</id>
+						<goals>
+							<goal>jar-no-fork</goal>
+						</goals>
 					</execution>
 				</executions>
 			</plugin>


### PR DESCRIPTION
By https://github.com/WorksApplications/Sudachi/issues/28, Sudachi deploys built `system.dic` as an artifact, then this repository can simplify build configuration like this.

I also found a problem which triggers #5. I fixed it in this PR.