### PR TITLE
Fix Part-of-Speech filter

### DIFF
--- a/src/main/java/com/worksap/nlp/elasticsearch/sudachi/index/SudachiPartOfSpeechFilterFactory.java
+++ b/src/main/java/com/worksap/nlp/elasticsearch/sudachi/index/SudachiPartOfSpeechFilterFactory.java
@@ -16,9 +16,7 @@
 
 package com.worksap.nlp.elasticsearch.sudachi.index;
 
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 
 import org.apache.lucene.analysis.TokenStream;
 import org.elasticsearch.common.settings.Settings;
@@ -38,10 +36,10 @@ public class SudachiPartOfSpeechFilterFactory extends
     public SudachiPartOfSpeechFilterFactory(IndexSettings indexSettings,
             Environment env, String name, Settings settings) {
         super(indexSettings, name, settings);
-        List<String> wordList = Analysis.getWordList(env, settings, "stoptags");
-        if (wordList != null) {
-            for (String word : wordList) {
-                stopTags.add(word.split(","));
+        List<String> tagList = Analysis.getWordList(env, settings, "stoptags");
+        if (tagList != null) {
+            for (String tag : tagList) {
+                stopTags.add(tag.split(","));
             }
         }
     }

--- a/src/main/java/com/worksap/nlp/elasticsearch/sudachi/index/SudachiPartOfSpeechFilterFactory.java
+++ b/src/main/java/com/worksap/nlp/elasticsearch/sudachi/index/SudachiPartOfSpeechFilterFactory.java
@@ -28,18 +28,21 @@ import org.elasticsearch.index.analysis.AbstractTokenFilterFactory;
 import org.elasticsearch.index.analysis.Analysis;
 
 import com.worksap.nlp.lucene.sudachi.ja.SudachiPartOfSpeechStopFilter;
+import com.worksap.nlp.lucene.sudachi.ja.PartOfSpeechTrie;
 
 public class SudachiPartOfSpeechFilterFactory extends
         AbstractTokenFilterFactory {
 
-    private final Set<String> stopTags = new HashSet<>();
+    private final PartOfSpeechTrie stopTags = new PartOfSpeechTrie();
 
     public SudachiPartOfSpeechFilterFactory(IndexSettings indexSettings,
             Environment env, String name, Settings settings) {
         super(indexSettings, name, settings);
         List<String> wordList = Analysis.getWordList(env, settings, "stoptags");
         if (wordList != null) {
-            stopTags.addAll(wordList);
+            for (String word : wordList) {
+                stopTags.add(word.split(","));
+            }
         }
     }
 

--- a/src/main/java/com/worksap/nlp/lucene/sudachi/ja/PartOfSpeechTrie.java
+++ b/src/main/java/com/worksap/nlp/lucene/sudachi/ja/PartOfSpeechTrie.java
@@ -33,11 +33,8 @@ public class PartOfSpeechTrie {
                 break;
             }
             @SuppressWarnings("unchecked")
-            Map<String, Object> newNode = (Map<String, Object>)node.get(item);
-            if (newNode == null) {
-                newNode = new HashMap<String, Object>();
-                node.put(item, newNode);
-            }
+            Map<String, Object> newNode =
+                (Map<String, Object>)node.computeIfAbsent(item, k -> new HashMap<>());
             node = newNode;
         }
     }

--- a/src/main/java/com/worksap/nlp/lucene/sudachi/ja/PartOfSpeechTrie.java
+++ b/src/main/java/com/worksap/nlp/lucene/sudachi/ja/PartOfSpeechTrie.java
@@ -1,0 +1,66 @@
+/*
+ *  Copyright (c) 2018 Works Applications Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.worksap.nlp.lucene.sudachi.ja;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class PartOfSpeechTrie {
+
+    static final String EMPTY_SYMBOL = "*";
+
+    Map<String, Object> root = new HashMap<>();
+
+    public void add(String... items) {
+        Map<String, Object> node = root;
+        for (String item : items) {
+            if (EMPTY_SYMBOL.equals(item)) {
+                break;
+            }
+            @SuppressWarnings("unchecked")
+            Map<String, Object> newNode = (Map<String, Object>)node.get(item);
+            if (newNode == null) {
+                newNode = new HashMap<String, Object>();
+                node.put(item, newNode);
+            }
+            node = newNode;
+        }
+    }
+
+    public boolean isPrefixOf(List<String> items, int begin, int end) {
+        if (root.isEmpty()) {
+            return false;
+        }
+        Map<String, Object> node = root;
+        for (int i = begin; i < end; i++) {
+            String item = items.get(i);
+            if (EMPTY_SYMBOL.equals(item)) {
+                return node.isEmpty();
+            }
+            @SuppressWarnings("unchecked")
+            Map<String, Object> newNode = (Map<String, Object>)node.get(item);
+            node = newNode;
+            if (node == null) {
+                return false;
+            } else if (node.isEmpty()) {
+                return true;
+            }
+        }
+        return true;
+    }
+}

--- a/src/main/java/com/worksap/nlp/lucene/sudachi/ja/SudachiAnalyzer.java
+++ b/src/main/java/com/worksap/nlp/lucene/sudachi/ja/SudachiAnalyzer.java
@@ -38,7 +38,7 @@ public class SudachiAnalyzer extends StopwordAnalyzerBase {
     private final Mode mode;
     private final String resourcesPath;
     private final String settings;
-    private final Set<String> stoptags;
+    private final PartOfSpeechTrie stoptags;
 
     public SudachiAnalyzer() {
         this(SudachiTokenizer.DEFAULT_MODE, "", null,
@@ -47,7 +47,7 @@ public class SudachiAnalyzer extends StopwordAnalyzerBase {
     }
 
     public SudachiAnalyzer(Mode mode, String resourcesPath, String settings,
-            CharArraySet stopwords, Set<String> stoptags) {
+            CharArraySet stopwords, PartOfSpeechTrie stoptags) {
         super(stopwords);
         this.mode = mode;
         this.resourcesPath = resourcesPath;
@@ -59,13 +59,13 @@ public class SudachiAnalyzer extends StopwordAnalyzerBase {
         return DefaultSetHolder.DEFAULT_STOP_SET;
     }
 
-    public static Set<String> getDefaultStopTags() {
+    public static PartOfSpeechTrie getDefaultStopTags() {
         return DefaultSetHolder.DEFAULT_STOP_TAGS;
     }
 
     private static class DefaultSetHolder {
         static final CharArraySet DEFAULT_STOP_SET;
-        static final Set<String> DEFAULT_STOP_TAGS;
+        static final PartOfSpeechTrie DEFAULT_STOP_TAGS;
 
         static {
             try {
@@ -73,10 +73,10 @@ public class SudachiAnalyzer extends StopwordAnalyzerBase {
                         "stopwords.txt", "#");
                 final CharArraySet tagset = loadStopwordSet(false,
                         SudachiAnalyzer.class, "stoptags.txt", "#");
-                DEFAULT_STOP_TAGS = new HashSet<>();
+                DEFAULT_STOP_TAGS = new PartOfSpeechTrie();
                 for (Object element : tagset) {
                     char[] chars = (char[]) element;
-                    DEFAULT_STOP_TAGS.add(new String(chars));
+                    DEFAULT_STOP_TAGS.add(new String(chars).split(","));
                 }
             } catch (IOException e) {
                 throw new UncheckedIOException(e);

--- a/src/main/java/com/worksap/nlp/lucene/sudachi/ja/SudachiAnalyzer.java
+++ b/src/main/java/com/worksap/nlp/lucene/sudachi/ja/SudachiAnalyzer.java
@@ -18,8 +18,6 @@ package com.worksap.nlp.lucene.sudachi.ja;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
-import java.util.HashSet;
-import java.util.Set;
 
 import org.apache.lucene.analysis.CharArraySet;
 import org.apache.lucene.analysis.StopwordAnalyzerBase;

--- a/src/main/java/com/worksap/nlp/lucene/sudachi/ja/SudachiPartOfSpeechStopFilter.java
+++ b/src/main/java/com/worksap/nlp/lucene/sudachi/ja/SudachiPartOfSpeechStopFilter.java
@@ -17,7 +17,6 @@
 package com.worksap.nlp.lucene.sudachi.ja;
 
 import java.util.List;
-import java.util.Map;
 
 import org.apache.lucene.analysis.FilteringTokenFilter;
 import org.apache.lucene.analysis.TokenStream;
@@ -48,7 +47,7 @@ public final class SudachiPartOfSpeechStopFilter extends FilteringTokenFilter {
     @Override
     protected boolean accept() {
         final List<String> pos = posAtt.getPartOfSpeechAsList();
-        if (pos == null) {
+        if (pos.isEmpty()) {
             return true;
         }
         if (stopTags.isPrefixOf(pos, 0, 4) || // POS w/o conjugation info

--- a/src/main/java/com/worksap/nlp/lucene/sudachi/ja/SudachiPartOfSpeechStopFilter.java
+++ b/src/main/java/com/worksap/nlp/lucene/sudachi/ja/SudachiPartOfSpeechStopFilter.java
@@ -50,11 +50,8 @@ public final class SudachiPartOfSpeechStopFilter extends FilteringTokenFilter {
         if (pos.isEmpty()) {
             return true;
         }
-        if (stopTags.isPrefixOf(pos, 0, 4) || // POS w/o conjugation info
-            stopTags.isPrefixOf(pos, 4, 6) || // conjugation type and form
-            stopTags.isPrefixOf(pos, 5, 6)) { // only conjugation form
-            return false;
-        }
-        return true;
+        return !stopTags.isPrefixOf(pos, 0, 4) && // POS w/o conjugation info
+            !stopTags.isPrefixOf(pos, 4, 6) && // conjugation type and form
+            !stopTags.isPrefixOf(pos, 5, 6); // only conjugation form
     }
 }

--- a/src/main/java/com/worksap/nlp/lucene/sudachi/ja/SudachiPartOfSpeechStopFilter.java
+++ b/src/main/java/com/worksap/nlp/lucene/sudachi/ja/SudachiPartOfSpeechStopFilter.java
@@ -17,7 +17,7 @@
 package com.worksap.nlp.lucene.sudachi.ja;
 
 import java.util.List;
-import java.util.Set;
+import java.util.Map;
 
 import org.apache.lucene.analysis.FilteringTokenFilter;
 import org.apache.lucene.analysis.TokenStream;
@@ -28,7 +28,7 @@ import com.worksap.nlp.lucene.sudachi.ja.tokenattribute.PartOfSpeechAttribute;
  * Removes tokens that match a set of part-of-speech tags.
  */
 public final class SudachiPartOfSpeechStopFilter extends FilteringTokenFilter {
-    private final Set<String> stopTags;
+    private final PartOfSpeechTrie stopTags;
     private final PartOfSpeechAttribute posAtt;
 
     /**
@@ -39,7 +39,7 @@ public final class SudachiPartOfSpeechStopFilter extends FilteringTokenFilter {
      * @param stopTags
      *            the part-of-speech tags that should be removed
      */
-    public SudachiPartOfSpeechStopFilter(TokenStream input, Set<String> stopTags) {
+    public SudachiPartOfSpeechStopFilter(TokenStream input, PartOfSpeechTrie stopTags) {
         super(input);
         this.stopTags = stopTags;
         posAtt = addAttribute(PartOfSpeechAttribute.class);
@@ -47,14 +47,14 @@ public final class SudachiPartOfSpeechStopFilter extends FilteringTokenFilter {
 
     @Override
     protected boolean accept() {
-        final List<String> posList = posAtt.getPartOfSpeechForArray();
-        if (posList == null || posList.isEmpty()) {
+        final List<String> pos = posAtt.getPartOfSpeechAsList();
+        if (pos == null) {
             return true;
         }
-        for (String pos : posList) {
-            if (stopTags.contains(pos)) {
-                return false;
-            }
+        if (stopTags.isPrefixOf(pos, 0, 4) || // POS w/o conjugation info
+            stopTags.isPrefixOf(pos, 4, 6) || // conjugation type and form
+            stopTags.isPrefixOf(pos, 5, 6)) { // only conjugation form
+            return false;
         }
         return true;
     }

--- a/src/main/java/com/worksap/nlp/lucene/sudachi/ja/SudachiPartOfSpeechStopFilterFactory.java
+++ b/src/main/java/com/worksap/nlp/lucene/sudachi/ja/SudachiPartOfSpeechStopFilterFactory.java
@@ -17,9 +17,7 @@
 package com.worksap.nlp.lucene.sudachi.ja;
 
 import java.io.IOException;
-import java.util.HashSet;
 import java.util.Map;
-import java.util.Set;
 
 import org.apache.lucene.analysis.CharArraySet;
 import org.apache.lucene.analysis.TokenStream;
@@ -30,7 +28,7 @@ import org.apache.lucene.analysis.util.TokenFilterFactory;
 public class SudachiPartOfSpeechStopFilterFactory extends TokenFilterFactory
         implements ResourceLoaderAware {
     private final String stopTagFiles;
-    private Set<String> stopTags;
+    private PartOfSpeechTrie stopTags;
 
     public SudachiPartOfSpeechStopFilterFactory(Map<String, String> args) {
         super(args);
@@ -48,10 +46,10 @@ public class SudachiPartOfSpeechStopFilterFactory extends TokenFilterFactory
         stopTags = null;
         CharArraySet cas = getWordSet(loader, stopTagFiles, false);
         if (cas != null) {
-            stopTags = new HashSet<>();
+            stopTags = new PartOfSpeechTrie();
             for (Object element : cas) {
                 char[] chars = (char[]) element;
-                stopTags.add(new String(chars));
+                stopTags.add(new String(chars).split(","));
             }
         }
     }

--- a/src/main/java/com/worksap/nlp/lucene/sudachi/ja/SudachiPartOfSpeechStopFilterFactory.java
+++ b/src/main/java/com/worksap/nlp/lucene/sudachi/ja/SudachiPartOfSpeechStopFilterFactory.java
@@ -33,15 +33,12 @@ public class SudachiPartOfSpeechStopFilterFactory extends TokenFilterFactory
     public SudachiPartOfSpeechStopFilterFactory(Map<String, String> args) {
         super(args);
         stopTagFiles = get(args, "tags");
-        if (args.containsKey("enablePositionIncrements")) {
-            throw new IllegalArgumentException(
-                    "enablePositionIncrements is not a valid option as of Lucene 5.0");
-        }
         if (!args.isEmpty()) {
             throw new IllegalArgumentException("Unknown parameters: " + args);
         }
     }
 
+    @Override
     public void inform(ResourceLoader loader) throws IOException {
         stopTags = null;
         CharArraySet cas = getWordSet(loader, stopTagFiles, false);

--- a/src/main/java/com/worksap/nlp/lucene/sudachi/ja/tokenattribute/PartOfSpeechAttribute.java
+++ b/src/main/java/com/worksap/nlp/lucene/sudachi/ja/tokenattribute/PartOfSpeechAttribute.java
@@ -23,7 +23,7 @@ import org.apache.lucene.util.Attribute;
 import com.worksap.nlp.sudachi.Morpheme;
 
 public interface PartOfSpeechAttribute extends Attribute {
-    public List<String> getPartOfSpeechForArray();
+    public List<String> getPartOfSpeechAsList();
 
     public String getPartOfSpeech();
 

--- a/src/main/java/com/worksap/nlp/lucene/sudachi/ja/tokenattribute/PartOfSpeechAttributeImpl.java
+++ b/src/main/java/com/worksap/nlp/lucene/sudachi/ja/tokenattribute/PartOfSpeechAttributeImpl.java
@@ -25,54 +25,20 @@ import org.apache.lucene.util.AttributeReflector;
 import com.worksap.nlp.sudachi.Morpheme;
 
 public class PartOfSpeechAttributeImpl extends AttributeImpl implements PartOfSpeechAttribute {
-    static final String EMPTY_COLUMN = "*";
-
     private Morpheme morpheme;
 
-    public List<String> getPartOfSpeechForArray() {
+    public List<String> getPartOfSpeechAsList() {
         if (morpheme == null) {
             return null;
         }
-
-        int i = 0;
-        List<String> posList = new ArrayList<>();
-        StringBuilder posBuilder = new StringBuilder();
-
-        for (String pos : morpheme.partOfSpeech()) {
-            if (i == 4) {
-                posList.add(posBuilder.toString());
-            }
-            if (EMPTY_COLUMN.equals(pos)) {
-                i++;
-                continue;
-            }
-            if (i < 4) {
-                if (posBuilder.length() != 0) {
-                    posBuilder.append(",");
-                }
-                posBuilder.append(pos);
-
-            } else {
-                posList.add(pos);
-            }
-            i++;
-        }
-        return posList;
+        return morpheme.partOfSpeech();
     }
 
     public String getPartOfSpeech() {
         if (morpheme == null) {
-            return null;
+            return "";
         }
-
-        StringBuilder posBuilder = new StringBuilder();
-        for (String pos : morpheme.partOfSpeech()) {
-            if (posBuilder.length() != 0) {
-                posBuilder.append(",");
-            }
-            posBuilder.append(pos);
-        }
-        return posBuilder.toString();
+        return String.join(",", morpheme.partOfSpeech());
     }
 
     public void setMorpheme(Morpheme morpheme) {

--- a/src/main/java/com/worksap/nlp/lucene/sudachi/ja/tokenattribute/PartOfSpeechAttributeImpl.java
+++ b/src/main/java/com/worksap/nlp/lucene/sudachi/ja/tokenattribute/PartOfSpeechAttributeImpl.java
@@ -16,7 +16,7 @@
 
 package com.worksap.nlp.lucene.sudachi.ja.tokenattribute;
 
-import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import org.apache.lucene.util.AttributeImpl;
@@ -29,7 +29,7 @@ public class PartOfSpeechAttributeImpl extends AttributeImpl implements PartOfSp
 
     public List<String> getPartOfSpeechAsList() {
         if (morpheme == null) {
-            return null;
+            return Collections.emptyList();
         }
         return morpheme.partOfSpeech();
     }

--- a/src/test/java/com/worksap/nlp/lucene/sudachi/ja/StringResourceLoader.java
+++ b/src/test/java/com/worksap/nlp/lucene/sudachi/ja/StringResourceLoader.java
@@ -1,0 +1,47 @@
+/*
+ *  Copyright (c) 2018 Works Applications Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.worksap.nlp.lucene.sudachi.ja;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+
+import org.apache.lucene.analysis.util.ResourceLoader;
+
+class StringResourceLoader implements ResourceLoader {
+    String text;
+        
+    public StringResourceLoader(String text) {
+        this.text = text;
+    }
+
+    @Override
+    public <T> Class<? extends T> findClass(String cname, Class<T> expectedType) {
+        throw new UnsupportedOperationException("not implemented");
+    }
+
+    @Override
+    public <T> T newInstance(String cname, Class<T> expectedType) {
+        throw new UnsupportedOperationException("not implemented");
+    }
+
+    @Override
+    public InputStream openResource(String resource) throws IOException {
+        return new ByteArrayInputStream(text.getBytes(StandardCharsets.UTF_8));
+    }
+}

--- a/src/test/java/com/worksap/nlp/lucene/sudachi/ja/TestSudachiPartOfSpeechStopFilter.java
+++ b/src/test/java/com/worksap/nlp/lucene/sudachi/ja/TestSudachiPartOfSpeechStopFilter.java
@@ -1,0 +1,79 @@
+/*
+ *  Copyright (c) 2018 Works Applications Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.worksap.nlp.lucene.sudachi.ja;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.StringReader;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.Rule;
+import org.junit.rules.TemporaryFolder;
+
+import org.apache.lucene.analysis.BaseTokenStreamTestCase;
+import org.apache.lucene.analysis.TokenStream;
+import org.apache.lucene.analysis.Tokenizer;
+
+public class TestSudachiPartOfSpeechStopFilter extends BaseTokenStreamTestCase {
+    TokenStream tokenStream;
+    SudachiPartOfSpeechStopFilterFactory factory;
+
+    @Rule
+    public TemporaryFolder tempFolderForDictionary = new TemporaryFolder();
+
+    public void setUp() throws Exception {
+        super.setUp();
+        tempFolderForDictionary.create();
+        File tempFileForDictionary = tempFolderForDictionary
+                .newFolder("sudachiDictionary");
+        ResourceUtil.copy(tempFileForDictionary);
+
+        String settings;
+        try (InputStream is = this.getClass().getResourceAsStream("sudachi.json")) {
+            settings = ResourceUtil.getSudachiSetting(is);
+        }
+
+        tokenStream = new SudachiTokenizer(true, SudachiTokenizer.Mode.NORMAL, tempFileForDictionary.getPath(), settings);
+        ((Tokenizer)tokenStream).setReader(new StringReader("東京都に行った。"));
+        factory = new SudachiPartOfSpeechStopFilterFactory(new HashMap<String, String>() {{ put("tags", "stoptags.txt"); }});
+    }
+
+    public void testFullPOS() throws IOException {
+        String tags = "動詞,非自立可能\n名詞,固有名詞,地名,一般\n";
+        factory.inform(new StringResourceLoader(tags));
+        tokenStream = factory.create(tokenStream);
+        assertTokenStreamContents(tokenStream, new String[] {"に", "た"});
+    }
+
+    public void testConjugationType() throws IOException {
+        String tags = "五段-カ行\n";
+        factory.inform(new StringResourceLoader(tags));
+        tokenStream = factory.create(tokenStream);
+        assertTokenStreamContents(tokenStream,
+                                  new String[] {"東京都", "に", "た"});
+    }
+
+    public void testConjugationForm() throws IOException {
+        String tags = "終止形-一般\n";
+        factory.inform(new StringResourceLoader(tags));
+        tokenStream = factory.create(tokenStream);
+        assertTokenStreamContents(tokenStream,
+                                  new String[] {"東京都", "に", "行く"});
+    }
+}

--- a/src/test/java/com/worksap/nlp/lucene/sudachi/ja/TestSudachiPartOfSpeechStopFilter.java
+++ b/src/test/java/com/worksap/nlp/lucene/sudachi/ja/TestSudachiPartOfSpeechStopFilter.java
@@ -49,16 +49,23 @@ public class TestSudachiPartOfSpeechStopFilter extends BaseTokenStreamTestCase {
             settings = ResourceUtil.getSudachiSetting(is);
         }
 
-        tokenStream = new SudachiTokenizer(true, SudachiTokenizer.Mode.NORMAL, tempFileForDictionary.getPath(), settings);
+        tokenStream = new SudachiTokenizer(true, SudachiTokenizer.Mode.SEARCH, tempFileForDictionary.getPath(), settings);
         ((Tokenizer)tokenStream).setReader(new StringReader("東京都に行った。"));
         factory = new SudachiPartOfSpeechStopFilterFactory(new HashMap<String, String>() {{ put("tags", "stoptags.txt"); }});
     }
 
-    public void testFullPOS() throws IOException {
+    public void testAllPOS() throws IOException {
         String tags = "動詞,非自立可能\n名詞,固有名詞,地名,一般\n";
         factory.inform(new StringResourceLoader(tags));
         tokenStream = factory.create(tokenStream);
-        assertTokenStreamContents(tokenStream, new String[] {"に", "た"});
+        assertTokenStreamContents(tokenStream, new String[] {"都", "に", "た"});
+    }
+
+    public void testPrefix() throws IOException {
+        String tags = "動詞\n名詞,固有名詞\n";
+        factory.inform(new StringResourceLoader(tags));
+        tokenStream = factory.create(tokenStream);
+        assertTokenStreamContents(tokenStream, new String[] {"都", "に", "た"});
     }
 
     public void testConjugationType() throws IOException {
@@ -66,7 +73,15 @@ public class TestSudachiPartOfSpeechStopFilter extends BaseTokenStreamTestCase {
         factory.inform(new StringResourceLoader(tags));
         tokenStream = factory.create(tokenStream);
         assertTokenStreamContents(tokenStream,
-                                  new String[] {"東京都", "に", "た"});
+                                  new String[] { "東京都", "東京", "都", "に", "た"});
+    }
+
+    public void testConjugationTypeAndForm() throws IOException {
+        String tags = "五段-カ行,終止形-一般\n";
+        factory.inform(new StringResourceLoader(tags));
+        tokenStream = factory.create(tokenStream);
+        assertTokenStreamContents(tokenStream,
+                                  new String[] { "東京都", "東京", "都", "に", "行く", "た"});
     }
 
     public void testConjugationForm() throws IOException {
@@ -74,6 +89,6 @@ public class TestSudachiPartOfSpeechStopFilter extends BaseTokenStreamTestCase {
         factory.inform(new StringResourceLoader(tags));
         tokenStream = factory.create(tokenStream);
         assertTokenStreamContents(tokenStream,
-                                  new String[] {"東京都", "に", "行く"});
+                                  new String[] {"東京都", "東京", "都", "に", "行く"});
     }
 }

--- a/src/test/java/com/worksap/nlp/lucene/sudachi/ja/TestSudachiPartOfSpeechStopFilterFactory.java
+++ b/src/test/java/com/worksap/nlp/lucene/sudachi/ja/TestSudachiPartOfSpeechStopFilterFactory.java
@@ -1,0 +1,73 @@
+/*
+ *  Copyright (c) 2018 Works Applications Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.worksap.nlp.lucene.sudachi.ja;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.StringReader;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.Rule;
+import org.junit.rules.TemporaryFolder;
+
+import org.apache.lucene.analysis.BaseTokenStreamTestCase;
+import org.apache.lucene.analysis.TokenStream;
+import org.apache.lucene.analysis.Tokenizer;
+
+public class TestSudachiPartOfSpeechStopFilterFactory extends BaseTokenStreamTestCase {
+    String path;
+    String settings;
+
+    @Rule
+    public TemporaryFolder tempFolderForDictionary = new TemporaryFolder();
+
+    public void setUp() throws Exception {
+        super.setUp();
+        tempFolderForDictionary.create();
+        File tempFileForDictionary = tempFolderForDictionary
+                .newFolder("sudachiDictionary");
+        ResourceUtil.copy(tempFileForDictionary);
+        path = tempFileForDictionary.getPath();
+
+        try (InputStream is = this.getClass().getResourceAsStream("sudachi.json")) {
+            settings = ResourceUtil.getSudachiSetting(is);
+        }
+    }
+
+    public void testBasics() throws IOException {
+        String tags = "動詞,非自立可能\n";
+        TokenStream ts = new SudachiTokenizer(true, SudachiTokenizer.Mode.NORMAL, path, settings);
+        ((Tokenizer)ts).setReader(new StringReader("東京都に行った。"));
+        Map<String, String> args = new HashMap<>();
+        args.put("tags", "stoptags.txt");
+        SudachiPartOfSpeechStopFilterFactory factory
+            = new SudachiPartOfSpeechStopFilterFactory(args);
+        factory.inform(new StringResourceLoader(tags));
+        ts = factory.create(ts);
+        assertTokenStreamContents(ts,
+                                  new String[] {"東京都", "に", "た"});
+    }
+
+    public void testBogusArguments() throws Exception {
+        IllegalArgumentException expected = expectThrows(IllegalArgumentException.class, () -> {
+                new SudachiPartOfSpeechStopFilterFactory(new HashMap<String, String>() {{ put("bogusArg", "bogusValue"); }});
+            });
+        assertTrue(expected.getMessage().contains("Unknown parameters"));
+    }
+}


### PR DESCRIPTION
Allow forward matching.

StopTags can forward-match followings
- POS[0, 4]
- POS[4, 6]
- POS[5]

See #21