### PR TITLE
Fix a bug of buffering a surrogate pair

### DIFF
--- a/src/main/java/com/worksap/nlp/lucene/sudachi/ja/SudachiTokenizer.java
+++ b/src/main/java/com/worksap/nlp/lucene/sudachi/ja/SudachiTokenizer.java
@@ -237,6 +237,9 @@ public final class SudachiTokenizer extends
         n += offset;
 
         int eos = lastIndexOfEos(buffer, n);
+        if (eos == n && Character.isHighSurrogate(buffer[n - 1])) {
+            eos -= 1;
+        }
         String sentences = new String(buffer, 0, eos);
         remainSize = n - eos;
         System.arraycopy(buffer, eos, buffer, 0, remainSize);

--- a/src/test/java/com/worksap/nlp/lucene/sudachi/ja/TestSudachiTokenizer.java
+++ b/src/test/java/com/worksap/nlp/lucene/sudachi/ja/TestSudachiTokenizer.java
@@ -345,4 +345,21 @@ public class TestSudachiTokenizer extends BaseTokenStreamTestCase {
         }
     }
 
+    @Test
+    public void testReadSentencesWithSurrogatePair() throws IOException {
+        int BUFFER_SIZE = 512;
+        String beforeSurrogatePair = "";
+        for (int i = 0; i < BUFFER_SIZE - 1; i++) {
+            beforeSurrogatePair += "a";
+        }
+        String afterSurrogatePair = "bbb";
+        String inputString = beforeSurrogatePair + "😜" + afterSurrogatePair;
+        tokenizer.setReader(new StringReader(inputString));
+        tokenizer.reset();
+        String[] answerList = { beforeSurrogatePair, "😜" + afterSurrogatePair };
+        for (int i = 0; i < answerList.length; i++) {
+            assertThat(tokenizer.readSentences(), is(answerList[i]));
+        }
+    }
+
 }


### PR DESCRIPTION
This branch fixes a bug of buffering a surrogate pair.

When the input string contains a surrogate pair at the boundary of the buffer, the surrogate pair is split wrongly and the exception is thrown in Sudachi.
This branch adjusts eos of the buffer to fix this problem.