### PR TITLE
Fix readSentences for chopped stream

### DIFF
--- a/src/main/java/com/worksap/nlp/lucene/sudachi/ja/SudachiTokenizer.java
+++ b/src/main/java/com/worksap/nlp/lucene/sudachi/ja/SudachiTokenizer.java
@@ -223,18 +223,20 @@ public final class SudachiTokenizer extends
             offset = remainSize;
             length -= remainSize;
         }
-        int n = input.read(buffer, offset, length);
-        if (n < 0) {
-            if (remainSize != 0) {
-                String lastSentence = new String(buffer, 0, remainSize);
-                baseOffset = nextBaseOffset;
-                nextBaseOffset += remainSize;
-                remainSize = 0;
-                return lastSentence;
+
+        while (length != 0) {
+            int ret = input.read(buffer, offset, length);
+            if (ret < 0) {
+                break;
             }
+            offset += ret;
+            length -= ret;
+        }
+        int n = offset;
+
+        if (n == 0) {
             return null;
         }
-        n += offset;
 
         int eos = lastIndexOfEos(buffer, n);
         if (eos == n && Character.isHighSurrogate(buffer[n - 1])) {

--- a/src/test/java/com/worksap/nlp/lucene/sudachi/ja/TestSudachiTokenizer.java
+++ b/src/test/java/com/worksap/nlp/lucene/sudachi/ja/TestSudachiTokenizer.java
@@ -23,6 +23,7 @@ import static org.junit.Assert.assertThat;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.Reader;
 import java.io.StringReader;
 
 import org.apache.lucene.analysis.BaseTokenStreamTestCase;
@@ -357,6 +358,48 @@ public class TestSudachiTokenizer extends BaseTokenStreamTestCase {
         tokenizer.setReader(new StringReader(inputString));
         tokenizer.reset();
         String[] answerList = { beforeSurrogatePair, "😜" + afterSurrogatePair };
+        for (int i = 0; i < answerList.length; i++) {
+            assertThat(tokenizer.readSentences(), is(answerList[i]));
+        }
+    }
+
+    private static class ChunkedStringReader extends Reader {
+        private char[] in;
+        private int chunkSize;
+        private int pos;
+        public ChunkedStringReader(String in, int chunkSize) {
+            this.in = in.toCharArray();
+            this.chunkSize = chunkSize;
+            this.pos = 0;
+        }
+
+        @Override
+        public void close() throws IOException {
+            this.pos = this.in.length;
+        }
+
+        @Override
+        public int read(char[] cbuf, int off, int len) throws IOException {
+            int length = len < this.chunkSize ? len : this.chunkSize;
+            if (length > this.in.length - this.pos) {
+                length = this.in.length - this.pos;
+            }
+            if (length == 0) {
+                return -1;
+            }
+            System.arraycopy(this.in, this.pos, cbuf, off, length);
+            this.pos += length;
+            return length;
+        }
+    }
+
+    @Test
+    public void testReadSentencesFromChunkedCharFilter() throws IOException {
+        String inputString = "Elasticsearch";
+        Reader charFilter = new ChunkedStringReader(inputString, 5);
+        tokenizer.setReader(charFilter);
+        tokenizer.reset();
+        String[] answerList = { "Elasticsearch" };
         for (int i = 0; i < answerList.length; i++) {
             assertThat(tokenizer.readSentences(), is(answerList[i]));
         }


### PR DESCRIPTION
This branch fixes `readSentences()` function for chunked streams.

Currently, the following code returns a wrong result because `read()` function of `ICUNormalizer2CharFilter` separates a result into 2 pieces.
```java
String input = "Elasticsearch";
Reader icuNormalizer = new ICUNormalizer2CharFilter(new StringReader(input));
SudachiTokenizer tokenizer = new SudachiTokenizer(true, SudachiTokenizer.Mode.SEARCH,
                tempFileForDictionary.getPath(), settings)
tokenizer.setReader(charFilter);
tokenizer.reset();
tokenizer.readSentences();  // => { "e", "lasticsearch" }
```

```java
String input = "Elasticsearch";
Reader icuNormalizer = new ICUNormalizer2CharFilter(new StringReader(input));
ret = icuNormalizer.read(buf, 0, 100);  // ret: 1,  buf: "e"
ret = icuNormalizer.read(buf, 0, 100);  // ret: 12, buf: "lasticsearch"
ret = icuNormalizer.read(buf, 0, 100);  // ret: -1
```