### PR TITLE
Fix documentation bugs and typos related to mode -> sudachi_split change in 2.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ analysis-sudachi is an Elasticsearch plugin for tokenization of Japanese text us
           "sudachi_tokenizer": {
             "type": "sudachi_tokenizer",
             "sudachi_split": "C",
-	          "discard_punctuation": true,
+            "discard_punctuation": true,
             "resources_path": "/etc/elasticsearch/sudachi"
           }
         },

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ analysis-sudachi is an Elasticsearch plugin for tokenization of Japanese text us
         "tokenizer": {
           "sudachi_tokenizer": {
             "type": "sudachi_tokenizer",
-            "mode": "C",
+            "sudachi_split": "C",
 	          "discard_punctuation": true,
             "resources_path": "/etc/elasticsearch/sudachi"
           }

--- a/src/main/java/com/worksap/nlp/elasticsearch/sudachi/index/SudachiTokenizerFactory.java
+++ b/src/main/java/com/worksap/nlp/elasticsearch/sudachi/index/SudachiTokenizerFactory.java
@@ -63,7 +63,7 @@ public class SudachiTokenizerFactory extends AbstractTokenizerFactory {
         }
 
         if (settings.hasValue(MODE_PARAM)) {
-            throw new IllegalArgumentException(MODE_PARAM + " is duprecated, use SudachiSplitFilter");
+            throw new IllegalArgumentException(MODE_PARAM + " is deprecated, use SudachiSplitFilter");
         }
 
         return mode;


### PR DESCRIPTION
I've found some minor issues during trying the latest elasticsearch-sudachi version.
This PR combines trivial fixes for them.