### PR TITLE
No duplicates for single char OOVs with SudachiSplitFilter extended mode

### DIFF
--- a/src/main/java/com/worksap/nlp/lucene/sudachi/ja/SudachiSplitFilter.java
+++ b/src/main/java/com/worksap/nlp/lucene/sudachi/ja/SudachiSplitFilter.java
@@ -126,7 +126,7 @@ public class SudachiSplitFilter extends TokenFilter {
         }
 
         if (input.incrementToken()) {
-            if (mode == Mode.EXTENDED && splitAtt.isOOV()) {
+            if (mode == Mode.EXTENDED && splitAtt.isOOV() && (termAtt.length() > 1)) {
                 oovChars.setOov(offsetAtt.startOffset(), termAtt.buffer(), termAtt.length());
                 posLengthAtt.setPositionLength(termAtt.length());
             } else {

--- a/src/test/java/com/worksap/nlp/lucene/sudachi/ja/TestSudachiSplitFilter.java
+++ b/src/test/java/com/worksap/nlp/lucene/sudachi/ja/TestSudachiSplitFilter.java
@@ -15,6 +15,8 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
+import jdk.internal.agent.resources.agent;
+
 public class TestSudachiSplitFilter extends BaseTokenStreamTestCase {
     TokenStream tokenStream;
 
@@ -105,6 +107,50 @@ public class TestSudachiSplitFilter extends BaseTokenStreamTestCase {
                                   new int[] { 1, 0, 1, 1, 1, 1, 1, 1 },
                                   new int[] { 4, 1, 1, 1, 1, 1, 1, 1 },
                                   9);
+    }
+
+    public void testWithSingleCharOOVBySearchMode() throws IOException {
+        tokenStream = setUpTokenStream("search", "あ");
+        assertTokenStreamContents(tokenStream,
+                                  new String[] { "あ" },
+                                  new int[] { 0 },
+                                  new int[] { 1 },
+                                  new int[] { 1 },
+                                  new int[] { 1 },
+                                  1);
+    }
+
+    public void testWithSingleCharOOVByExtendedMode() throws IOException {
+        tokenStream = setUpTokenStream("extended", "あ");
+        assertTokenStreamContents(tokenStream,
+                                  new String[] { "あ" },
+                                  new int[] { 0 },
+                                  new int[] { 1 },
+                                  new int[] { 1 },
+                                  new int[] { 1 },
+                                  1);
+    }
+
+    public void testWithSingleCharOOVSequenceBySearchMode() throws IOException {
+        tokenStream = setUpTokenStream("search", "アマゾン");
+        assertTokenStreamContents(tokenStream,
+                                  new String[] { "ア", "マ", "ゾ", "ン"  },
+                                  new int[] { 0, 1, 2, 3 },
+                                  new int[] { 1, 2, 3, 4 },
+                                  new int[] { 1, 1, 1, 1 },
+                                  new int[] { 1, 1, 1, 1 },
+                                  4);
+    }
+
+    public void testWithSingleCharOOVSequenceByExtendedMode() throws IOException {
+        tokenStream = setUpTokenStream("extended", "アマゾン");
+        assertTokenStreamContents(tokenStream,
+                                  new String[] { "ア", "マ", "ゾ", "ン"  },
+                                  new int[] { 0, 1, 2, 3 },
+                                  new int[] { 1, 2, 3, 4 },
+                                  new int[] { 1, 1, 1, 1 },
+                                  new int[] { 1, 1, 1, 1 },
+                                  4);
     }
 
     TokenStream setUpTokenStream(String mode, String input) {

--- a/src/test/java/com/worksap/nlp/lucene/sudachi/ja/TestSudachiSplitFilter.java
+++ b/src/test/java/com/worksap/nlp/lucene/sudachi/ja/TestSudachiSplitFilter.java
@@ -15,7 +15,6 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
-
 public class TestSudachiSplitFilter extends BaseTokenStreamTestCase {
     TokenStream tokenStream;
 

--- a/src/test/java/com/worksap/nlp/lucene/sudachi/ja/TestSudachiSplitFilter.java
+++ b/src/test/java/com/worksap/nlp/lucene/sudachi/ja/TestSudachiSplitFilter.java
@@ -15,7 +15,6 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
-import jdk.internal.agent.resources.agent;
 
 public class TestSudachiSplitFilter extends BaseTokenStreamTestCase {
     TokenStream tokenStream;


### PR DESCRIPTION
Related: #62 

`SudachiSplitFilter`'s "extended" mode creates extra per-character tokens for OOV. 

They are currently created even when the OOV itself is a single character;
e.g., `"アマゾン"` becomes `{ "ア", "ア", "マ", "マ", "ゾ", "ゾ", "ン", "ン" }`.

This PR fixes this issue.