### PR TITLE
Use Gradle 7 to build the project

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,21 +17,17 @@ jobs:
       with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
     - name: Set up JDK 11
-      uses: actions/setup-java@v1
+      uses: actions/setup-java@v2
       with:
         java-version: 11
+        distribution: 'temurin'
+        cache: 'gradle'
     - name: Cache SonarCloud packages
       uses: actions/cache@v1
       with:
         path: ~/.sonar/cache
         key: ${{ runner.os }}-sonar
         restore-keys: ${{ runner.os }}-sonar
-    - name: Cache Gradle packages
-      uses: actions/cache@v2
-      with:
-        path: ~/.gradle/caches
-        key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
-        restore-keys: ${{ runner.os }}-gradle
     - name: Build and analyze
       uses: eskatos/gradle-command-action@v1
       with:

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'java-library'
-    id 'org.sonarqube' version '3.0'
+    id 'org.sonarqube' version '3.3'
     id 'jacoco'
 }
 
@@ -8,8 +8,9 @@ group = 'com.worksap.nlp'
 archivesBaseName = 'analysis-sudachi'
 version = '2.1.1-SNAPSHOT'
 
-sourceCompatibility = 1.8
-targetCompatibility = 1.8
+tasks.withType(JavaCompile) {
+    options.release = 8
+}
 
 repositories {
     mavenCentral()
@@ -21,28 +22,30 @@ dependencies {
     testRuntimeOnly "org.apache.logging.log4j:log4j-core:2.11.1"
 }
 
-task buildTestDict(dependsOn: 'processTestResources', type: JavaExec) {
-    main = 'com.worksap.nlp.sudachi.dictionary.DictionaryBuilder'
+def buildTestDict = tasks.register('buildTestDict', JavaExec) {
+    dependsOn processTestResources
+    mainClass = 'com.worksap.nlp.sudachi.dictionary.DictionaryBuilder'
     classpath = sourceSets.main.runtimeClasspath
     args('-o', 'build/resources/test/com/worksap/nlp/lucene/sudachi/ja/system_core.dic', '-m', 'src/test/dict/matrix.def', 'src/test/dict/lex.csv')
 }
 test.dependsOn buildTestDict
 
-task embedVersion(type: Copy) {
+def embedVersion = tasks.register('embedVersion', Copy) {
     from 'src/main/extras/plugin-descriptor.properties'
     into 'build/descriptor'
     expand([version: version, elasticsearchVersion: elasticsearchVersion])
 }
 
-task copyDependencies(type: Copy) {
+def copyDependencies = tasks.register('copyDependencies', Copy) {
     def libs = ['sudachi', 'javax.json', 'jdartsclone']
     from configurations.runtimeClasspath.collect { f -> (libs.any { f.name.startsWith(it) }) ? f : null }
     into 'build/libs'
 }
 
-task distZip(dependsOn: ['jar', 'embedVersion', 'copyDependencies'], type: Zip) {
+def distZip = tasks.register('distZip', Zip) {
+    dependsOn 'jar', embedVersion, copyDependencies
     archiveBaseName = archivesBaseName
-    appendix = elasticsearchVersion
+    archiveAppendix = elasticsearchVersion
     from 'build/libs/', 'build/descriptor', 'LICENSE', 'README.md'
 }
 
@@ -60,7 +63,7 @@ sonarqube {
 
 jacocoTestReport {
     reports {
-        xml.enabled true
+        xml.required = true
     }
     dependsOn test
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = "elasticsearch-sudachi"


### PR DESCRIPTION
Hello, 👋 

I want to suggest bumping up Gradle from 6 to 7, to enhance build performance by the [configuration cache](https://docs.gradle.org/current/userguide/configuration_cache.html). Actually, there are fewer build performance enhancements, because this repo is enough small and simple for now.

This PR also contains several minor changes:

* Replace `actions/cache` with the built-in dependencies cache in `actions/setup-java`, which provides [better performance](https://github.com/actions/setup-java/pull/193#issuecomment-901865758).
* Replace deprecated task definition with suggested `tasks.register()` API, refer [the GRadle official manual](https://docs.gradle.org/7.3.1/userguide/task_configuration_avoidance.html) for detail.
* Create a [`settings.gradle` file which is always suggested to have in Gradle projects](https://docs.gradle.org/7.3.1/userguide/organizing_gradle_projects.html#always_define_a_settings_file).
* Bump up the `org.sonarqube` Gradle plugin to the latest release.
* Use `--release` option instead of `targetCompatibility`. It helps us to avoid depending on Java API which does not exists in Java 8.

Thanks for checking my PR! Hope that it helps your daily hacking.