### PR TITLE
Bumps log4j-core to 2.17.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@ repositories {
 dependencies {
     implementation 'com.worksap.nlp:sudachi:0.5.3', "org.elasticsearch.client:transport:${elasticsearchVersion}"
     testImplementation "org.elasticsearch.test:framework:${elasticsearchVersion}"
-    testRuntimeOnly "org.apache.logging.log4j:log4j-core:2.16.0"
+    testRuntimeOnly "org.apache.logging.log4j:log4j-core:2.17.0"
 }
 
 def buildTestDict = tasks.register('buildTestDict', JavaExec) {


### PR DESCRIPTION
https://nvd.nist.gov/vuln/detail/CVE-2021-45105
