### PR TITLE
Refine MorphemeConsumerAttribute

### DIFF
--- a/spi/src/main/java/com/worksap/nlp/lucene/sudachi/ja/attributes/MorphemeConsumerAttribute.java
+++ b/spi/src/main/java/com/worksap/nlp/lucene/sudachi/ja/attributes/MorphemeConsumerAttribute.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Works Applications Co., Ltd.
+ * Copyright (c) 2023-2024 Works Applications Co., Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,12 +16,13 @@
 
 package com.worksap.nlp.lucene.sudachi.ja.attributes;
 
+import java.util.List;
 import org.apache.lucene.util.Attribute;
 
 /**
  * This attribute tells Sudachi-based TokenStreams not to produce anything into
  * {@link org.apache.lucene.analysis.tokenattributes.CharTermAttribute} if it is
- * not the current consumer. <br>
+ * not in the current consumer list. <br>
  * This is performance optimisation and will not change correctness if resetting
  * {@code CharTermAttribute} before writing into it.
  */
@@ -31,24 +32,48 @@ public interface MorphemeConsumerAttribute extends Attribute {
      * 
      * @param consumer
      *            object that will try to consume the token stream
-     * @return true if the object is current consumer
+     * @return true if the object is one of current consumers
      */
     default boolean shouldConsume(Object consumer) {
-        return consumer == getCurrentConsumer();
+        return getCurrentConsumers().contains(consumer);
     }
 
     /**
-     * Get the current consumer
+     * Get the list of the current consumers.
      * 
-     * @return instance that is current consumer
+     * @return instance list of current consumers, in the order of insertion
      */
-    Object getCurrentConsumer();
+    List<Object> getCurrentConsumers();
 
     /**
-     * Set the current consumer for the token stream
+     * Remove the last consumer in the list if it is the provided one. Otherwise
+     * no-op.
+     * 
+     * @param consumer
+     *            consumer instance to drop
+     */
+    void dropLastConsumer(Object consumer);
+
+    /**
+     * Add a consumer for the token stream.
      * 
      * @param consumer
      *            new consumer instance
      */
-    void setCurrentConsumer(Object consumer);
+    void addConsumer(Object consumer);
+
+    /**
+     * Add a consumer for the token stream, removing the last consumer if it becomes
+     * no-op.
+     *
+     * @param consumer
+     *            new consumer instance
+     * @param previous
+     *            previous {@link org.apache.lucene.analysis.TokenStream} to check
+     *            update
+     */
+    default void updateCurrentConsumers(Object consumer, Object previous) {
+        dropLastConsumer(previous);
+        addConsumer(consumer);
+    }
 }

--- a/src/main/java/com/worksap/nlp/lucene/sudachi/ja/SudachiTokenizer.kt
+++ b/src/main/java/com/worksap/nlp/lucene/sudachi/ja/SudachiTokenizer.kt
@@ -37,7 +37,8 @@ class SudachiTokenizer(
   private val offsetAtt = addAttribute<OffsetAttribute>()
   private val posIncAtt = addAttribute<PositionIncrementAttribute>()
   private val posLenAtt = addAttribute<PositionLengthAttribute>()
-  private val consumer = addAttribute<MorphemeConsumerAttribute> { it.currentConsumer = this }
+  private val consumer =
+      addAttribute<MorphemeConsumerAttribute> { it.updateCurrentConsumers(this, null) }
 
   init {
     addAttribute<SudachiAttribute> { it.dictionary = tokenizer.dictionary }
@@ -62,7 +63,9 @@ class SudachiTokenizer(
     posIncAtt.positionIncrement = 1
     val baseOffset = iterator.baseOffset
     offsetAtt.setOffset(correctOffset(baseOffset + m.begin()), correctOffset(baseOffset + m.end()))
-    termAtt.setEmpty().append(m.surface())
+    if (consumer.shouldConsume(this)) {
+      termAtt.setEmpty().append(m.surface())
+    }
     return true
   }
 

--- a/src/main/java/com/worksap/nlp/lucene/sudachi/ja/attributes/MorphemeConsumerAttributeImpl.kt
+++ b/src/main/java/com/worksap/nlp/lucene/sudachi/ja/attributes/MorphemeConsumerAttributeImpl.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2023 Works Applications Co., Ltd.
+ * Copyright (c) 2022-2024 Works Applications Co., Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,22 +27,25 @@ import org.apache.lucene.util.AttributeReflector
  * This is not a token-based attribute, so impl's clear/copyTo do nothing
  */
 class MorphemeConsumerAttributeImpl : AttributeImpl(), MorphemeConsumerAttribute {
-  private var instance: Any = Companion
+  private var instances: MutableList<Any> = mutableListOf()
+
   // does nothing
   override fun clear() {}
-
-  override fun reflectWith(reflector: AttributeReflector) {
-    reflector.reflect<MorphemeConsumerAttribute>("instance", instance.javaClass.name)
-  }
-
   override fun copyTo(target: AttributeImpl?) {}
 
-  override fun getCurrentConsumer(): Any = instance
-
-  override fun setCurrentConsumer(consumer: Any?) {
-    instance = consumer!!
+  override fun reflectWith(reflector: AttributeReflector) {
+    reflector.reflect<MorphemeConsumerAttribute>("instances", instances.map { it.javaClass.name })
   }
 
-  // need something to use as initial value of [instance] variable
-  private companion object
+  override fun getCurrentConsumers(): List<Any> = instances
+
+  override fun dropLastConsumer(consumer: Any?) {
+    if (!instances.isEmpty() && consumer === instances.last()) {
+      instances.removeLast()
+    }
+  }
+
+  override fun addConsumer(consumer: Any?) {
+    instances.add(consumer!!)
+  }
 }


### PR DESCRIPTION
fix #123.

This PR makes **_breaking changes_** to SPI.
We need to consider when to merge this.

MorphemeConsumerAttribute suggests which sudachi tokenizer/filter should set the term attribute.
Previously MCA only keeps the final component as a consumer and this makes problem when there are filters that use term attribute beforehand.
This pr makes MCA to keep multiple consumers to resolve the problem.

The latest consumer in the list can be safely dropped if there are no filters that use term attribute between that consumer and current.
Current implementation only detects the case of consecutive consumer filters (which we need only the last consumer).
We may detect more complex cases in the future.