### PR TITLE
Update github actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,48 +42,47 @@ jobs:
       githubRef: ${{ github.ref }}
     continue-on-error: true
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
-    - name: Set up JDK 17
-      uses: actions/setup-java@v3
+    - name: Setup JDK 17
+      uses: actions/setup-java@v4
       with:
         java-version: 17
         distribution: 'temurin'
     - name: Cache SonarCloud packages
       if: env.mainJob == 'true'
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ~/.sonar/cache
         key: ${{ runner.os }}-sonar-${{ hashFiles('build.gradle') }}
-    - name: Extract version
-      uses: eskatos/gradle-command-action@v2
+    - name: Setup Gradle
+      uses: gradle/actions/setup-gradle@v3
       with:
-        arguments: -PengineVersion=${{ matrix.es-version }} printVersionForGithubActions
-        cache-read-only: false # ${{ github.ref != 'refs/heads/develop' }}
+        cache-read-only: false
+    - name: Extract version and set to github env
+      run: ./gradlew -PengineVersion=${{ matrix.es-version }} printVersionForGithubActions
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    - name: Build # This stage sets up gradle caching
-      uses: eskatos/gradle-command-action@v2
-      with:
-        arguments: -PengineVersion=${{ matrix.es-version }} --info clean build koverXmlReport
+    - name: Setup Gradle again with caching
+      uses: gradle/actions/setup-gradle@v3
+    - name: Build
+      run: ./gradlew -PengineVersion=${{ matrix.es-version }} --info clean build koverXmlReport
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - name: Analyze with sonarqube
       if: env.mainJob == 'true'
-      uses: eskatos/gradle-command-action@v2
-      with:
-        arguments: -PengineVersion=${{ matrix.es-version }} --info sonar
+      run: ./gradlew -PengineVersion=${{ matrix.es-version }} --info sonar
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
     - name: Cache elasticsearch download
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: build/integration/${{ env.ENGINE_KIND }}-${{ env.ENGINE_VERSION }}-linux-x86_64.tar.gz
         key: ${{ env.ENGINE_KIND }}-${{ env.ENGINE_VERSION }}
     - name: Cache dictionary download
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: build/integration/sudachi-dictionary-20230110-small.zip
         key: sudachi-dictionary-20230110
@@ -114,33 +113,31 @@ jobs:
         python3 test-scripts/20-put-docs.py
         python3 test-scripts/30-test-docs.py
         bash test-scripts/80-delete-index.sh
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       name: Upload reports when failed
       if: failure()
       with:
-        name: failure-reports
+        name: failure-reports-${{ matrix.es-version }}
         path: |
           build/reports
           build/integration/elasticsearch-*/logs
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       name: Upload built packages
       if: success()
       with:
-        name: build-artifacts
+        name: build-artifacts-${{ matrix.es-version }}
         path: |
           build/distributions/*.zip
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       name: Upload SPI jar
       if: env.mainJob == 'true'
       with:
-        name: build-artifacts
+        name: build-artifacts-spi-${{ matrix.es-version }}
         path: |
           spi/build/libs/sudachi-*.jar
     - name: 'Publish SPI jar to maven central'
-      uses: eskatos/gradle-command-action@v2
       if: env.mainJob == 'true' && success() && startsWith(github.ref, 'refs/heads/develop')
-      with:
-        arguments: -PengineVersion=${{ matrix.es-version }} --info publishToSonatype closeAndReleaseSonatypeStagingRepository
+      run: ./gradlew -PengineVersion=${{ matrix.es-version }} --info publishToSonatype closeAndReleaseSonatypeStagingRepository
       env:
         GITHUB_USERNAME: GITHUB_ACTOR
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,7 +39,6 @@ jobs:
           - 'os:2.6.0'
     env:
       mainJob: ${{ matrix.es-version == 'es:8.13.4' }}
-      githubRef: ${{ github.ref }}
     continue-on-error: true
     steps:
     - uses: actions/checkout@v4
@@ -117,7 +116,7 @@ jobs:
       name: Upload reports when failed
       if: failure()
       with:
-        name: failure-reports-${{ matrix.es-version }}
+        name: failure-reports-${{ env.ENGINE_KIND }}-${{ env.ENGINE_VERSION }}
         path: |
           build/reports
           build/integration/elasticsearch-*/logs
@@ -125,14 +124,14 @@ jobs:
       name: Upload built packages
       if: success()
       with:
-        name: build-artifacts-${{ matrix.es-version }}
+        name: build-artifacts-${{ env.ENGINE_KIND }}-${{ env.ENGINE_VERSION }}
         path: |
           build/distributions/*.zip
     - uses: actions/upload-artifact@v4
       name: Upload SPI jar
       if: env.mainJob == 'true'
       with:
-        name: build-artifacts-spi-${{ matrix.es-version }}
+        name: build-artifacts-spi-${{ env.ENGINE_KIND }}-${{ env.ENGINE_VERSION }}
         path: |
           spi/build/libs/sudachi-*.jar
     - name: 'Publish SPI jar to maven central'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,14 +57,10 @@ jobs:
         key: ${{ runner.os }}-sonar-${{ hashFiles('build.gradle') }}
     - name: Setup Gradle
       uses: gradle/actions/setup-gradle@v3
-      with:
-        cache-read-only: false
     - name: Extract version and set to github env
       run: ./gradlew -PengineVersion=${{ matrix.es-version }} printVersionForGithubActions
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    - name: Setup Gradle again with caching
-      uses: gradle/actions/setup-gradle@v3
     - name: Build
       run: ./gradlew -PengineVersion=${{ matrix.es-version }} --info clean build koverXmlReport
       env:


### PR DESCRIPTION
resolve #128.

- For `upload-artifact`, followed their [migration guide](https://github.com/actions/upload-artifact/blob/main/docs/MIGRATION.md)
- [`eskatos/gradle-command-action`](https://github.com/eskatos/gradle-command-action) seems moved to [`gradle/gradle-build-action`](https://github.com/gradle/gradle-build-action), which is also superceded by [`gradle/actions/setup-gradle`](https://github.com/gradle/actions?tab=readme-ov-file#the-setup-gradle-action)