### PR TITLE
separate workflow for sonar

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: build
+name: Build and test
 
 on:
   push:
@@ -49,12 +49,6 @@ jobs:
       with:
         java-version: 17
         distribution: 'temurin'
-    - name: Cache SonarCloud packages
-      if: env.mainJob == 'true'
-      uses: actions/cache@v4
-      with:
-        path: ~/.sonar/cache
-        key: ${{ runner.os }}-sonar-${{ hashFiles('build.gradle') }}
     - name: Setup Gradle
       uses: gradle/actions/setup-gradle@v3
     - name: Extract version and set to github env
@@ -65,12 +59,6 @@ jobs:
       run: ./gradlew -PengineVersion=${{ matrix.es-version }} --info clean build koverXmlReport
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    - name: Analyze with sonarqube
-      if: env.mainJob == 'true'
-      run: ./gradlew -PengineVersion=${{ matrix.es-version }} --info sonar
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
     - name: Cache elasticsearch download
       uses: actions/cache@v4
       with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,6 +40,7 @@ jobs:
     env:
       mainJob: ${{ matrix.es-version == 'es:8.13.4' }}
     continue-on-error: true
+
     steps:
     - uses: actions/checkout@v4
       with:
@@ -55,10 +56,28 @@ jobs:
       run: ./gradlew -PengineVersion=${{ matrix.es-version }} printVersionForGithubActions
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
     - name: Build
       run: ./gradlew -PengineVersion=${{ matrix.es-version }} --info clean build koverXmlReport
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Prepare artifact for sonar analysis
+      if: env.mainJob == 'true'
+      run: |
+        find -iname build -type d -exec tar -cf sonar.tar {} \+
+        echo ${{ github.event.number }} >> PR_EVENT.txt
+        echo ${{ github.event.pull_request.head.ref }} >> PR_EVENT.txt
+        echo ${{ github.event.pull_request.base.ref }} >> PR_EVENT.txt
+    - name: Upload artifact for sonar analysis
+      if: env.mainJob == 'true'
+      uses: actions/upload-artifact@v4
+      with:
+        name: sonar-artifact
+        path: |
+          sonar.tar
+          PR_EVENT.txt
+
     - name: Cache elasticsearch download
       uses: actions/cache@v4
       with:
@@ -104,6 +123,7 @@ jobs:
         path: |
           build/reports
           build/integration/elasticsearch-*/logs
+
     - uses: actions/upload-artifact@v4
       name: Upload built packages
       if: success()
@@ -118,6 +138,7 @@ jobs:
         name: build-artifacts-spi-${{ env.ENGINE_KIND }}-${{ env.ENGINE_VERSION }}
         path: |
           spi/build/libs/sudachi-*.jar
+
     - name: 'Publish SPI jar to maven central'
       if: env.mainJob == 'true' && success() && startsWith(github.ref, 'refs/heads/develop')
       run: ./gradlew -PengineVersion=${{ matrix.es-version }} --info publishToSonatype closeAndReleaseSonatypeStagingRepository

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -1,0 +1,34 @@
+name: Sonarqube
+
+on:
+  workflow_run:
+    workflows: ["Build and test"]
+    types:
+      - completed
+
+jobs:
+  sonar:
+    name: Sonar
+    if: github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+      with:
+          fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
+    - name: Setup JDK 17
+      uses: actions/setup-java@v4
+      with:
+        java-version: 17
+        distribution: 'temurin'
+    - name: Setup Gradle
+      uses: gradle/actions/setup-gradle@v3
+    - name: Cache SonarCloud packages
+      uses: actions/cache@v4
+      with:
+        path: ~/.sonar/cache
+        key: ${{ runner.os }}-sonar-${{ hashFiles('build.gradle') }}
+    - name: Analyze with sonarqube
+      run: ./gradlew --info sonar
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -11,10 +11,14 @@ jobs:
     name: Sonar
     if: github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
+
     steps:
-    - uses: actions/checkout@v4
+    - name: Checkout develop or PR branch
+      uses: actions/checkout@v4
       with:
-          fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
+        repository: ${{ github.event.workflow_run.head_repository.full_name }}
+        ref: ${{ github.event.workflow_run.head_branch }}
+        fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of Sonar analysis
     - name: Setup JDK 17
       uses: actions/setup-java@v4
       with:
@@ -22,13 +26,41 @@ jobs:
         distribution: 'temurin'
     - name: Setup Gradle
       uses: gradle/actions/setup-gradle@v3
+
     - name: Cache SonarCloud packages
       uses: actions/cache@v4
       with:
         path: ~/.sonar/cache
         key: ${{ runner.os }}-sonar-${{ hashFiles('build.gradle') }}
-    - name: Analyze with sonarqube
+
+    - name: Download sonar artifact
+      uses: actions/download-artifact@v4
+      with:
+        name: sonar-artifact
+        run-id: ${{ github.event.workflow_run.id }}
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        merge-multiple: true
+    - name: Extract sonar artifact
+      run: |
+        tar -xf sonar.tar
+        echo "PR_NUMBER=$(sed '1q;d' PR_EVENT.txt)" >> "$GITHUB_ENV"
+        echo "PR_HEAD_REF=$(sed '2q;d' PR_EVENT.txt)" >> "$GITHUB_ENV"
+        echo "PR_BASE_REF=$(sed '3q;d' PR_EVENT.txt)" >> "$GITHUB_ENV"
+  
+    - name: Analyze with sonarqube (push develop)
+      if: github.event.workflow_run.event == 'push'
       run: ./gradlew --info sonar
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+    - name: Analyze with sonarqube (PR)
+      if: github.event.workflow_run.event == 'pull_request'
+      run: >
+        ./gradlew --info sonar
+          -Dsonar.scm.revision=${{ github.event.workflow_run.head_sha }}
+          -Dsonar.pullrequest.key=${{ env.PR_NUMBER }}
+          -Dsonar.pullrequest.branch=${{ env.PR_HEAD_REF }}
+          -Dsonar.pullrequest.base=${{ env.PR_BASE_REF }}
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
fix #134.

Currently sonarcloud does not provides analysis for PR from forked repo ([open issue](https://portal.productboard.com/sonarsource/1-sonarcloud/c/50-sonarcloud-analyzes-external-pull-request)).
To use secret tokens safely, we can separate workflow for `sonar` task using `workflow_run` trigger.

This triggered workflow misses the information about PR and we need to pass it somehow (in this PR, via artifact).

ref: https://community.sonarsource.com/t/how-to-use-sonarcloud-with-a-forked-repository-on-github/7363/30