### PR TITLE
Release/v3.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,20 @@
 
 ## [Unreleased](https://github.com/WorksApplications/elasticsearch-sudachi/releases/)
 
+## [3.4.0](https://github.com/WorksApplications/elasticsearch-sudachi/releases/tag/v3.4.0) - 2026-01-27
+
 ### Added
 
 - Support OpenSearch 2.18.0
-- Support OpenSearch 2.19.* ([#170](https://github.com/WorksApplications/elasticsearch-sudachi/pull/170))
+- Support OpenSearch 2.19.\* ([#170](https://github.com/WorksApplications/elasticsearch-sudachi/pull/170))
 - Support Elasticsearch 8.16.6 and 8.17.10 ([#172](https://github.com/WorksApplications/elasticsearch-sudachi/pull/172))
 
+### Changed
+
+- Update Java version from 11 to 17 ([#172](https://github.com/WorksApplications/elasticsearch-sudachi/pull/172))
+
 ### Removed
+
 - Elasticsearch 7.x and versions earlier than 8.10 will no longer be supported. ([#172](https://github.com/WorksApplications/elasticsearch-sudachi/pull/172))
 
 ## [3.3.0](https://github.com/WorksApplications/elasticsearch-sudachi/releases/tag/v3.3.0) - 2024-11-13

--- a/README.md
+++ b/README.md
@@ -9,7 +9,9 @@ analysis-sudachi is an Elasticsearch plugin for tokenization of Japanese text us
 
 - [3.4.0]
   - Support Elasticsearch 8.16.6 and 8.17.10.
+  - Support OpenSearch 2.18.0 and 2.19.4.
   - Elasticsearch 7.x and versions earlier than 8.10 will no longer be supported.
+  - Update Java version from 11 to 17
 
 Check [changelog](./CHANGELOG.md) for more.
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,4 +11,4 @@ org.gradle.jvmargs=-XX:MaxMetaspaceSize=350m \
   --add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED
 org.gradle.caching=true
 org.gradle.parallel=true
-pluginVersion=3.4.0
+pluginVersion=3.4.1-SNAPSHOT

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,4 +11,4 @@ org.gradle.jvmargs=-XX:MaxMetaspaceSize=350m \
   --add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED
 org.gradle.caching=true
 org.gradle.parallel=true
-pluginVersion=3.3.1-SNAPSHOT
+pluginVersion=3.4.0


### PR DESCRIPTION
release v3.4.0

- we skip es 8.18~.
  - we need to handle the problem around the entailment policy
- we skip es 9~ and os 3~, as they requires java 21.