### PR TITLE
fix backport workflow

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -14,16 +14,16 @@ jobs:
   backport:
     name: Backport merged PR
     runs-on: ubuntu-latest
-    # closed: when PR is merged with label `backport-*`
-    # labeled: when `backport-*` label is added to a merged PR
+    # closed: when PR is merged with label `backport *`
+    # labeled: when `backport *` label is added to a merged PR
     if: >
       (github.event.action == 'closed' &&
        github.event.pull_request.merged == true &&
-       contains(join(github.event.pull_request.labels.*.name, ' '), 'backport-'))
+       contains(join(github.event.pull_request.labels.*.name, ' '), 'backport '))
       ||
       (github.event.action == 'labeled' &&
        github.event.pull_request.merged == true &&
-       startsWith(github.event.label.name, 'backport-'))
+       startsWith(github.event.label.name, 'backport '))
     steps:
       - name: Expand backport label into target branches
         id: targets

--- a/docs/multi-engine-code-management-policy.en.md
+++ b/docs/multi-engine-code-management-policy.en.md
@@ -100,9 +100,9 @@ Whether cherry-pick/backport is required, and which target branches are involved
 Specify the backport target by adding the label `backport [target branch]` to the source PR (e.g. `backport es-9`).
 If backporting to multiple branches is required, the following shorthand labels may also be used.
 
-- `backport-es`: backport to all Elasticsearch series
-- `backport-os`: backport to all OpenSearch series
-- `backport-all`: backport to all series
+- `backport es`: backport to all Elasticsearch series
+- `backport os`: backport to all OpenSearch series
+- `backport all`: backport to all series
 
 When the PR is merged (or when the label is added if it has already been merged), an action to create the backport PR is triggered, and completion is defined as the merge of that generated backport PR.
 

--- a/docs/multi-engine-code-management-policy.md
+++ b/docs/multi-engine-code-management-policy.md
@@ -100,9 +100,9 @@ cherrypick/backport の要否と対象ブランチの確認は PR 単位で行�
 該当する元 PR にラベル `backport [target branch]` (e.g. `backport es-9`) を付与することで backport 先を指定する。
 複数ブランチへのbackport が必要な場合は以下の省略形も使用可能。
 
-- `backport-es`：すべての Elasticsearch 系列に backport する
-- `backport-os`：すべての OpenSearch 系列に backport する
-- `backport-all`：すべての系列に backport する
+- `backport es`：すべての Elasticsearch 系列に backport する
+- `backport os`：すべての OpenSearch 系列に backport する
+- `backport all`：すべての系列に backport する
 
 当該 PR のマージ時（マージ済みならラベル付与時）にバックポート PR 作成のアクションが実行されるので、これのマージをもって完了とする。
 


### PR DESCRIPTION
Target branch: `develop`

workflow yml and document contains both `backport-*` and `backport *` label pattern.
This PR aligns them to `backport *`.