### PR TITLE
fix `./build.gradle` for os-3 sonar workflow

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,8 +7,6 @@ plugins {
     id 'org.sonarqube' version '7.2.2.6593'
 
     id 'com.worksap.nlp.sudachi.es.extension'
-    id 'com.worksap.nlp.sudachi.es.sources'
-    id 'com.worksap.nlp.sudachi.es.dependencies'
     id 'com.worksap.nlp.sudachi.esc'
 }
 


### PR DESCRIPTION
target branch: `develop`

remove unnecessary dependency/source plugin to avoid jvm version mismatch (happened in https://github.com/WorksApplications/elasticsearch-sudachi/actions/runs/23782849505/job/69299180547).
