### PR TITLE
fix release workflow

### DIFF
--- a/.github/workflows/release-orchestrator.yml
+++ b/.github/workflows/release-orchestrator.yml
@@ -39,10 +39,10 @@ jobs:
     - uses: actions/checkout@v6
       with:
         fetch-depth: 0
-    - name: Ensure tag commit is on default branch
+    - name: Ensure tag commit is on default branch (`develop`)
       if: github.event_name == 'push'
       run: |
-        git fetch origin develop --depth=1
+        git fetch origin develop
         git merge-base --is-ancestor "$GITHUB_SHA" origin/develop
     - id: meta
       env:


### PR DESCRIPTION
target branch: `develop`
backport: none (orchestrator only works on `develop`)

fetch all commits so that we can correctly check `--is-ancestor`.