### PR TITLE
fix release workflow

### DIFF
--- a/.github/workflows/release-series.yml
+++ b/.github/workflows/release-series.yml
@@ -148,4 +148,4 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         RELEASE_TAG: ${{ inputs.release_tag }}
-      run: gh release upload "$RELEASE_TAG" dist/* --clobber
+      run: gh release upload "$RELEASE_TAG" dist/* --clobber -R "${{ github.repository }}"


### PR DESCRIPTION
target branch: `develop`
backport: `all`

provide repository to upload explicitly in gh cli.