### PR TITLE
fix release workflow

### DIFF
--- a/.github/workflows/release-orchestrator.yml
+++ b/.github/workflows/release-orchestrator.yml
@@ -120,7 +120,7 @@ jobs:
           --method POST \
           -H "Accept: application/vnd.github+json" \
           "/repos/${{ github.repository }}/actions/workflows/$DISPATCH_WORKFLOW_FILE/dispatches" \
-          -f ref="$TARGET_REF" \
+          -f ref="develop" \
           -F inputs[branch]="$TARGET_BRANCH" \
           -F inputs[target_ref]="$TARGET_REF" \
           -F inputs[release_tag]="$RELEASE_TAG"


### PR DESCRIPTION
target branch: `develop`
backport: none

dispatch series workflow in the develop branch, instead of target ref
- this is most loose setting that all series/tag will be released via workflow in the latest develop branch
- we may narrow this from `develop` to `$TARGET_BRANCH` or `$TARGET_REF`, to use different workflow for each series/tag.
