### PR TITLE
prepare for the new branch for es8.18+

### DIFF
--- a/.github/branch-support-matrix.json
+++ b/.github/branch-support-matrix.json
@@ -7,9 +7,24 @@
       "versions": []
     },
     {
-      "branch": "es-8.10-plus",
+      "branch": "es-8.18-plus",
       "release_enabled": true,
       "upload_spi": true,
+      "versions": [
+        {
+          "engine_version": "es:8.19.15",
+          "java_version": "17"
+        },
+        {
+          "engine_version": "es:8.18.8",
+          "java_version": "17"
+        }
+      ]
+    },
+    {
+      "branch": "es-8.10-8.17",
+      "release_enabled": true,
+      "upload_spi": false,
       "versions": [
         {
           "engine_version": "es:8.17.10",

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -35,7 +35,7 @@ jobs:
           script: |
             // definitions
             const labelPattern = /^backport (.+)$/
-            const esBranches = ["es-8.10-plus"]
+            const esBranches = ["es-8.18-plus", "es-8.10-8.17"]
             const osBranches = ["os-3", "os-2.6-plus"]
             const groups = {
               "es": esBranches,

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Check [changelog](./CHANGELOG.md) for more.
 # Build (if necessary)
 
 1. Check the branch which supports the target version and checkout.
-  - Either `es-8.10-plus`, `os-2.6-plus`, `os-3`.
+  - Either `es-8.10-8.17`, `es-8.18-plus`, `os-2.6-plus`, `os-3`.
   - See [support martix file](.github/branch-support-matrix.json).
 2. Build analysis-sudachi.
 
@@ -29,7 +29,8 @@ Use `-PengineVersion=os:2.19.3` for OpenSearch.
 
 ## Supported ElasticSearch versions
 
-1. (`es-8.10-plus`) 8.10.* until 8.17.* supported, integration tests in CI
+1. (`es-8.10-8.17`) 8.10.* until 8.17.* supported, integration tests in CI
+2. (`es-8.18-plus`) 8.18.* until 8.19.* supported, integration tests in CI
 
 ## Supported OpenSearch versions
 

--- a/docs/multi-engine-code-management-policy.en.md
+++ b/docs/multi-engine-code-management-policy.en.md
@@ -23,7 +23,8 @@ This document defines the policy for managing those branches.
 In addition, maintain branches for each supported search engine and its major version.
 
 - `es-9`: Elasticsearch v9.\* and later (not yet supported in v3.4.0)
-- `es-8.10-plus`: Elasticsearch v8.10.\* and later
+- `es-8.18-plus`: Elasticsearch v8.18.\* and later
+- `es-8.10-8.17`: Elasticsearch v8.10.\* till v8.17.\*
 - `os-3`: OpenSearch v3.\* and later
 - `os-2.6-plus`: OpenSearch v2.6.\* and later
 

--- a/docs/multi-engine-code-management-policy.md
+++ b/docs/multi-engine-code-management-policy.md
@@ -23,7 +23,8 @@ Elasticsearch / OpenSearch やそのバージョンによって API が異なる
 さらに対応する検索エンジンおよびそのメジャーバージョン毎にブランチを持つ
 
 - `es-9`: Elasticsearch v9.\* 以降（v3.4.0 では未対応）
-- `es-8.10-plus`: Elasticsearch v8.10.\* 以降
+- `es-8.18-plus`: Elasticsearch v8.18.\* 以降
+- `es-8.10-8.17`: Elasticsearch v8.10.\* から v8.17.\*
 - `os-3`: OpenSearch v3.\* 以降
 - `os-2.6-plus`: OpenSearch v2.6.\* 以降
 


### PR DESCRIPTION
target branch: `develop`
backport to: `es` (to sync `.github/branch-support-matrix.json`)

Update things to add new branch `es-8.18-plus`.

before merge, we also need to:
- update branch name (`es-8.10-plus` to `es-8.10-8.17`)
- update labels for backport