### PR TITLE
update url for maven publishing

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -145,6 +145,8 @@ tasks.register("printVersionForGithubActions") {
 nexusPublishing {
     repositories {
         sonatype {
+            nexusUrl = uri("https://ossrh-staging-api.central.sonatype.com/service/local/")
+            snapshotRepositoryUrl = uri("https://central.sonatype.com/repository/maven-snapshots/")
             username = project.findProperty("maven.user") ?: System.getenv("MAVEN_USERNAME")
             password = project.findProperty("maven.password") ?: System.getenv("MAVEN_USER_PASSWORD")
         }


### PR DESCRIPTION
target: `develop`
backport: none (we only release spi from develop branch)

update release url following https://github.com/WorksApplications/Sudachi/pull/364