### PR TITLE
Update Sudachi version to v0.8.0

### DIFF
--- a/lucene/build.gradle
+++ b/lucene/build.gradle
@@ -51,7 +51,7 @@ if (sudachiEs.jvmVersion() >= 21) {
 
 dependencies {
     api(project(':spi'))
-    api('com.worksap.nlp:sudachi:0.7.4')
+    api('com.worksap.nlp:sudachi:0.8.0')
 
     testImplementation(project(':testlib'))
     testImplementation('org.apache.logging.log4j:log4j-core:2.17.2')

--- a/lucene/src/test/java/com/worksap/nlp/lucene/sudachi/ja/TestSudachiTokenizer.kt
+++ b/lucene/src/test/java/com/worksap/nlp/lucene/sudachi/ja/TestSudachiTokenizer.kt
@@ -19,7 +19,6 @@ package com.worksap.nlp.lucene.sudachi.ja
 import com.worksap.nlp.lucene.sudachi.ja.input.CopyingInputExtractor
 import com.worksap.nlp.lucene.sudachi.ja.input.NoopInputExtractor
 import com.worksap.nlp.lucene.sudachi.ja.plugin.AnalysisCache
-import com.worksap.nlp.lucene.sudachi.ja.ResourceUtil
 import com.worksap.nlp.lucene.sudachi.ja.plugin.ReloadableDictionary
 import com.worksap.nlp.sudachi.Config
 import com.worksap.nlp.sudachi.PathAnchor
@@ -48,7 +47,7 @@ open class TestSudachiTokenizer : BaseTokenStreamTestCase() {
       mode: SplitMode,
       noPunctuation: Boolean = true,
       allowEmptyMorpheme: Boolean = false,
-      capacity: Int = 0
+      capacity: Int = 0,
   ): SudachiTokenizer {
     val dict = ReloadableDictionary(config.allowEmptyMorpheme(allowEmptyMorpheme))
     val extractor =
@@ -57,7 +56,12 @@ open class TestSudachiTokenizer : BaseTokenStreamTestCase() {
         } else {
           CopyingInputExtractor(Short.MAX_VALUE.toInt())
         }
-    val tok = CachingTokenizer(dict.newTokenizer(), mode, AnalysisCache(InnerCacheBuilderImpl().build(capacity), extractor))
+    val tok =
+        CachingTokenizer(
+            dict.newTokenizer(),
+            mode,
+            AnalysisCache(InnerCacheBuilderImpl().build(capacity), extractor),
+        )
     return SudachiTokenizer(tok, noPunctuation, AttributeFactory.DEFAULT_ATTRIBUTE_FACTORY)
   }
 
@@ -315,7 +319,7 @@ open class TestSudachiTokenizer : BaseTokenStreamTestCase() {
     )
 
     var anchor = PathAnchor.filesystem(testDic.root.toPath().resolve("config/sudachi"))
-    anchor = anchor.andThen(PathAnchor.classpath(ResourceUtil::class.java))
+    anchor = anchor.andThen(PathAnchor.classpath())
     config =
         Config.fromClasspath(ResourceUtil::class.java.getResource("additional.json"), anchor)
             .withFallback(config)

--- a/search/build.gradle
+++ b/search/build.gradle
@@ -53,7 +53,7 @@ compileTestKotlin {
 dependencies {
     api(project(':spi'))
     api(project(':lucene'))
-    implementation('com.worksap.nlp:sudachi:0.7.4')
+    implementation('com.worksap.nlp:sudachi:0.8.0')
     testImplementation(project(':testlib'))
     testImplementation('org.apache.logging.log4j:log4j-core:2.17.2')
     testImplementation('org.jetbrains.kotlin:kotlin-test-junit') {

--- a/spi/build.gradle
+++ b/spi/build.gradle
@@ -14,7 +14,7 @@ version = properties["pluginVersion"]
 description = "Plugin interface for Sudachi search engine integrations (ElasticSearch and OpenSearch)"
 
 dependencies {
-    api('com.worksap.nlp:sudachi:0.7.4')
+    api('com.worksap.nlp:sudachi:0.8.0')
 }
 
 spotless {


### PR DESCRIPTION
target: `develop`
backport: `all`

Update Sudachi version to v0.8.0.
This is mainly for es 8.18 and later which require to load resources in a jar via the class loader.

As PathAnchor behavior changed, we also fix a test that uses it.