### PR TITLE
prepare for the new branch `es-9`

### DIFF
--- a/.github/branch-support-matrix.json
+++ b/.github/branch-support-matrix.json
@@ -2,14 +2,35 @@
   "branches": [
     {
       "branch": "es-9",
-      "release_enabled": false,
-      "upload_spi": false,
-      "versions": []
+      "release_enabled": true,
+      "upload_spi": true,
+      "versions": [
+        {
+          "engine_version": "es:9.4.1",
+          "java_version": "21"
+        },
+        {
+          "engine_version": "es:9.3.4",
+          "java_version": "21"
+        },
+        {
+          "engine_version": "es:9.2.8",
+          "java_version": "21"
+        },
+        {
+          "engine_version": "es:9.1.10",
+          "java_version": "21"
+        },
+        {
+          "engine_version": "es:9.0.8",
+          "java_version": "21"
+        }
+      ]
     },
     {
       "branch": "es-8.18-plus",
       "release_enabled": true,
-      "upload_spi": true,
+      "upload_spi": false,
       "versions": [
         {
           "engine_version": "es:8.19.15",

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -35,7 +35,7 @@ jobs:
           script: |
             // definitions
             const labelPattern = /^backport (.+)$/
-            const esBranches = ["es-8.18-plus", "es-8.10-8.17"]
+            const esBranches = ["es-9", "es-8.18-plus", "es-8.10-8.17"]
             const osBranches = ["os-3", "os-2.6-plus"]
             const groups = {
               "es": esBranches,
@@ -65,6 +65,7 @@ jobs:
       - name: Create backport PRs
         id: backport
         # Keep third-party actions pinned to a commit SHA for supply-chain safety.
+        # https://github.com/korthout/backport-action/releases/tag/v4.5.2
         uses: korthout/backport-action@4aaf0e03a94ff0a619c9a511b61aeb42adea5b02
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Check [changelog](./CHANGELOG.md) for more.
 # Build (if necessary)
 
 1. Check the branch which supports the target version and checkout.
-  - Either `es-8.10-8.17`, `es-8.18-plus`, `os-2.6-plus`, `os-3`.
+  - Either `es-8.10-8.17`, `es-8.18-plus`, `es-9`, `os-2.6-plus`, `os-3`.
   - See [support martix file](.github/branch-support-matrix.json).
 2. Build analysis-sudachi.
 
@@ -31,6 +31,7 @@ Use `-PengineVersion=os:2.19.3` for OpenSearch.
 
 1. (`es-8.10-8.17`) 8.10.* until 8.17.* supported, integration tests in CI
 2. (`es-8.18-plus`) 8.18.* until 8.19.* supported, integration tests in CI
+3. (`es-9`) 9.0.* until 9.4.* supported, integration tests in CI
 
 ## Supported OpenSearch versions
 

--- a/docs/multi-engine-code-management-policy.en.md
+++ b/docs/multi-engine-code-management-policy.en.md
@@ -22,7 +22,7 @@ This document defines the policy for managing those branches.
 
 In addition, maintain branches for each supported search engine and its major version.
 
-- `es-9`: Elasticsearch v9.\* and later (not yet supported in v3.4.0)
+- `es-9`: Elasticsearch v9.\* and later
 - `es-8.18-plus`: Elasticsearch v8.18.\* and later
 - `es-8.10-8.17`: Elasticsearch v8.10.\* till v8.17.\*
 - `os-3`: OpenSearch v3.\* and later

--- a/docs/multi-engine-code-management-policy.md
+++ b/docs/multi-engine-code-management-policy.md
@@ -22,7 +22,7 @@ Elasticsearch / OpenSearch やそのバージョンによって API が異なる
 
 さらに対応する検索エンジンおよびそのメジャーバージョン毎にブランチを持つ
 
-- `es-9`: Elasticsearch v9.\* 以降（v3.4.0 では未対応）
+- `es-9`: Elasticsearch v9.\* 以降
 - `es-8.18-plus`: Elasticsearch v8.18.\* 以降
 - `es-8.10-8.17`: Elasticsearch v8.10.\* から v8.17.\*
 - `os-3`: OpenSearch v3.\* 以降


### PR DESCRIPTION
target branch: `develop`
backport to: `es-8.18-plus` and `es-9` (to sync .github/branch-support-matrix.json)

Update things to add new branch es-9.

before merge, we also need to:
- update labels for backport
