### PR TITLE
Follow es9 api change

### DIFF
--- a/buildSrc/src/main/groovy/com/worksap/nlp/tools/EsConventions.groovy
+++ b/buildSrc/src/main/groovy/com/worksap/nlp/tools/EsConventions.groovy
@@ -8,10 +8,9 @@ class EsConventions implements Plugin<Project> {
     @Override
     void apply(Project target) {
         target.tasks.withType(JavaCompile).configureEach {
-            options.release.set(17)
+            options.release.set(21)
             options.encoding = 'UTF-8'
         }
-
 
         target.repositories {
             mavenLocal()

--- a/buildSrc/src/main/groovy/com/worksap/nlp/tools/EsExtensionPlugin.groovy
+++ b/buildSrc/src/main/groovy/com/worksap/nlp/tools/EsExtensionPlugin.groovy
@@ -48,19 +48,4 @@ class EsExtension {
     String engineVersion() {
         return kind.get().versionString
     }
-
-    /**
-     * Returns the required JVM version for the current engine.
-     * OpenSearch 3.0+ requires JVM 21, others use JVM 17.
-     */
-    int jvmVersion() {
-        var k = kind.get()
-        if (k.engine == EngineType.OpenSearch) {
-            var version = k.parsedVersion()
-            if (version.ge(3, 0)) {
-                return 21
-            }
-        }
-        return 17
-    }
 }

--- a/buildSrc/src/main/groovy/com/worksap/nlp/tools/engines.groovy
+++ b/buildSrc/src/main/groovy/com/worksap/nlp/tools/engines.groovy
@@ -7,9 +7,8 @@ trait EngineSupport {
 }
 
 enum EsSupport implements EngineSupport {
-    Es810("es-8", "es-8.10"),
-    Es812("es-8", "es-8.12"),
-    Es816("es-8", "es-8.16")
+    Es900("es-9", "es-9.0"),
+    Es940("es-9", "es-9.4"),
 
     String majorTag
     String minorTag
@@ -29,14 +28,12 @@ enum EsSupport implements EngineSupport {
     }
 
     static EsSupport supportVersion(Version vers) {
-        if (vers.lt(8, 10)) {
-            throw new IllegalArgumentException("versions below 8.10 are not supported")
-        } else if (vers.ge(8, 10) && vers.lt(8, 12)) {
-            return Es810
-        } else if (vers.ge(8, 12) && vers.lt(8, 16)) {
-            return Es812
-        } else if (vers.ge(8, 16) && vers.lt(9, 0)) {
-            return Es816
+        if (vers.lt(9, 0)) {
+            throw new IllegalArgumentException("versions below 9.0 are not supported")
+        } else if (vers.ge(9, 0) && vers.lt(9, 4)) {
+            return Es900
+        } else if (vers.ge(9, 4)) {
+            return Es940
         } else {
             throw new IllegalArgumentException("unsupported ElasticSearch version: " + vers.raw)
         }

--- a/integration/build.gradle
+++ b/integration/build.gradle
@@ -17,37 +17,6 @@ plugins {
 group = 'com.worksap.nlp'
 version = properties["pluginVersion"]
 
-// JVM target is determined by engine version (OpenSearch 3.0+ requires JVM 21)
-def jvmVersion = sudachiEs.jvmVersion()
-def jvmTargetVersion = jvmVersion == 21 ? JvmTarget.JVM_21 : JvmTarget.JVM_17
-def javaVersion = jvmVersion == 21 ? JavaVersion.VERSION_21 : JavaVersion.VERSION_17
-
-java {
-    sourceCompatibility = javaVersion
-    targetCompatibility = javaVersion
-}
-
-tasks.withType(JavaCompile).configureEach {
-    options.release = jvmVersion
-}
-
-compileKotlin {
-    compilerOptions.jvmTarget.set(jvmTargetVersion)
-}
-
-compileTestKotlin {
-    compilerOptions.jvmTarget.set(jvmTargetVersion)
-}
-
-// For OpenSearch 3.0+, we need to tell Gradle that JDK 21+ libraries are compatible
-if (jvmVersion >= 21) {
-    configurations.all {
-        attributes {
-            attribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE, jvmVersion)
-        }
-    }
-}
-
 configurations { buildSudachiDict }
 
 dependencies {

--- a/integration/build.gradle
+++ b/integration/build.gradle
@@ -10,6 +10,7 @@ plugins {
 
     id 'com.worksap.nlp.sudachi.es.extension'
     id 'com.worksap.nlp.sudachi.es.dependencies'
+    id 'com.worksap.nlp.sudachi.es.sources'
     id 'com.worksap.nlp.sudachi.es.testenv'
     id 'com.worksap.nlp.sudachi.esc'
 }

--- a/integration/src/test/ext/es-9.0/SudachiInSearchEngineEnv.kt
+++ b/integration/src/test/ext/es-9.0/SudachiInSearchEngineEnv.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2026 Works Applications Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.worksap.nlp.elasticsearch.sudachi
+
+import org.elasticsearch.plugins.PluginsLoader
+import org.elasticsearch.plugins.PluginsService
+
+fun SudachiInSearchEngineEnv.makePluginService(): PluginsService {
+  val loader =
+      PluginsLoader.createPluginsLoader(
+          PluginsLoader.loadModulesBundles(environment().modulesDir()),
+          PluginsLoader.loadPluginsBundles(pluginsPath),
+          emptyMap(),
+      )
+  return PluginsService(settings(), configPath, loader)
+}

--- a/integration/src/test/ext/es-9.4/SudachiInSearchEngineEnv.kt
+++ b/integration/src/test/ext/es-9.4/SudachiInSearchEngineEnv.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2026 Works Applications Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.worksap.nlp.elasticsearch.sudachi
+
+import org.elasticsearch.plugins.PluginsLoader
+import org.elasticsearch.plugins.PluginsService
+
+fun SudachiInSearchEngineEnv.makePluginService(): PluginsService {
+  val loader =
+      PluginsLoader.createPluginsLoader(
+          PluginsLoader.loadModulesBundles(environment().modulesDir(), false),
+          PluginsLoader.loadPluginsBundles(pluginsPath, false),
+          emptyMap(),
+      )
+  return PluginsService(settings(), configPath, loader)
+}

--- a/integration/src/test/java/com/worksap/nlp/elasticsearch/sudachi/SudachiInSearchEngineEnv.kt
+++ b/integration/src/test/java/com/worksap/nlp/elasticsearch/sudachi/SudachiInSearchEngineEnv.kt
@@ -23,8 +23,6 @@ import org.elasticsearch.env.Environment
 import org.elasticsearch.index.analysis.AnalysisRegistry
 import org.elasticsearch.indices.analysis.AnalysisModule
 import org.elasticsearch.plugins.AnalysisPlugin
-import org.elasticsearch.plugins.PluginsLoader
-import org.elasticsearch.plugins.PluginsService
 import org.elasticsearch.test.ESTestCase
 
 class SudachiInSearchEngineEnv {
@@ -47,20 +45,10 @@ class SudachiInSearchEngineEnv {
     return Environment(settings(), configPath)
   }
 
-  fun makePluginService(): PluginsService {
-    val loader =
-        PluginsLoader.createPluginsLoader(
-            PluginsLoader.loadModulesBundles(environment().modulesDir()),
-            PluginsLoader.loadPluginsBundles(pluginsPath),
-            emptyMap(),
-        )
-    return PluginsService(settings(), configPath, loader)
-  }
-
   fun makeAnalysisModule(): AnalysisModule {
+    val env = environment()
     val plugins = makePluginService()
     val analysisPlugins = plugins.filterPlugins(AnalysisPlugin::class.java).toList()
-    val env = environment()
     return AnalysisModule(env, analysisPlugins, plugins.stablePluginRegistry)
   }
 }

--- a/lucene/build.gradle
+++ b/lucene/build.gradle
@@ -16,37 +16,9 @@ group = 'com.worksap.nlp'
 version = properties["pluginVersion"]
 description = "Main logic for Sudachi search engine integrations (ElasticSearch and OpenSearch)"
 
-// JVM target is determined by engine version (OpenSearch 3.0+ requires JVM 21)
-def jvmVersion = sudachiEs.jvmVersion()
-def jvmTargetVersion = jvmVersion == 21 ? JvmTarget.JVM_21 : JvmTarget.JVM_17
-def javaVersion = jvmVersion == 21 ? JavaVersion.VERSION_21 : JavaVersion.VERSION_17
-
 java {
-    sourceCompatibility = javaVersion
-    targetCompatibility = javaVersion
     withJavadocJar()
     withSourcesJar()
-}
-
-tasks.withType(JavaCompile).configureEach {
-    options.release = jvmVersion
-}
-
-compileKotlin {
-    compilerOptions.jvmTarget.set(jvmTargetVersion)
-}
-
-compileTestKotlin {
-    compilerOptions.jvmTarget.set(jvmTargetVersion)
-}
-
-// For OpenSearch 3.0+, we need to tell Gradle that JDK 21+ libraries are compatible
-if (sudachiEs.jvmVersion() >= 21) {
-    configurations.all {
-        attributes {
-            attribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE, sudachiEs.jvmVersion())
-        }
-    }
 }
 
 dependencies {

--- a/search/build.gradle
+++ b/search/build.gradle
@@ -18,37 +18,6 @@ base.archivesName = properties["pluginName"]
 version = properties["pluginVersion"]
 description = "Plugin implementation for Sudachi search engine integrations (ElasticSearch and OpenSearch)"
 
-// JVM target is determined by engine version (OpenSearch 3.0+ requires JVM 21)
-def jvmVersion = sudachiEs.jvmVersion()
-def jvmTargetVersion = jvmVersion == 21 ? JvmTarget.JVM_21 : JvmTarget.JVM_17
-def javaVersion = jvmVersion == 21 ? JavaVersion.VERSION_21 : JavaVersion.VERSION_17
-
-java {
-    sourceCompatibility = javaVersion
-    targetCompatibility = javaVersion
-}
-
-tasks.withType(JavaCompile).configureEach {
-    options.release = jvmVersion
-}
-
-// For OpenSearch 3.0+, we need to tell Gradle that JDK 21+ libraries are compatible
-if (jvmVersion >= 21) {
-    configurations.all {
-        attributes {
-            attribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE, jvmVersion)
-        }
-    }
-}
-
-compileKotlin {
-    compilerOptions.jvmTarget.set(jvmTargetVersion)
-}
-
-compileTestKotlin {
-    compilerOptions.jvmTarget.set(jvmTargetVersion)
-}
-
 dependencies {
     api(project(':spi'))
     api(project(':lucene'))

--- a/search/src/main/java/com/worksap/nlp/elasticsearch/sudachi/index/SudachiAnalyzerProvider.kt
+++ b/search/src/main/java/com/worksap/nlp/elasticsearch/sudachi/index/SudachiAnalyzerProvider.kt
@@ -36,8 +36,8 @@ class SudachiAnalyzerProvider(
     indexSettings: IndexSettings,
     env: Environment,
     name: String,
-    settings: Settings
-) : AbstractIndexAnalyzerProvider<SudachiAnalyzer>(name, settings) {
+    settings: Settings,
+) : AbstractIndexAnalyzerProvider<SudachiAnalyzer>(name) {
 
   private val stopWords: Set<*> by lazy {
     parseStopWords(env, settings, SudachiAnalyzer.getDefaultStopSet(), false)
@@ -69,7 +69,7 @@ class SudachiAnalyzerProvider(
     @JvmStatic
     fun maker(
         dictionaryService: DictionaryService,
-        cacheService: AnalysisCacheService
+        cacheService: AnalysisCacheService,
     ): AnalysisProvider<AnalyzerProvider<out Analyzer?>> {
       return AnalysisProvider { indexSettings, environment, name, settings ->
         SudachiAnalyzerProvider(

--- a/search/src/main/java/com/worksap/nlp/elasticsearch/sudachi/index/SudachiBaseFormFilterFactory.kt
+++ b/search/src/main/java/com/worksap/nlp/elasticsearch/sudachi/index/SudachiBaseFormFilterFactory.kt
@@ -27,8 +27,8 @@ class SudachiBaseFormFilterFactory(
     indexSettings: IndexSettings?,
     environment: Environment?,
     name: String?,
-    settings: Settings?
-) : AbstractTokenFilterFactory(name, settings) {
+    settings: Settings?,
+) : AbstractTokenFilterFactory(name) {
   override fun create(tokenStream: TokenStream): TokenStream {
     return SudachiBaseFormFilter(tokenStream)
   }

--- a/search/src/main/java/com/worksap/nlp/elasticsearch/sudachi/index/SudachiNormalizedFormFilterFactory.kt
+++ b/search/src/main/java/com/worksap/nlp/elasticsearch/sudachi/index/SudachiNormalizedFormFilterFactory.kt
@@ -27,8 +27,8 @@ class SudachiNormalizedFormFilterFactory(
     indexSettings: IndexSettings?,
     environment: Environment?,
     name: String?,
-    settings: Settings?
-) : AbstractTokenFilterFactory(name, settings) {
+    settings: Settings?,
+) : AbstractTokenFilterFactory(name) {
   override fun create(tokenStream: TokenStream): TokenStream {
     return SudachiNormalizedFormFilter(tokenStream)
   }

--- a/search/src/main/java/com/worksap/nlp/elasticsearch/sudachi/index/SudachiPartOfSpeechFilterFactory.kt
+++ b/search/src/main/java/com/worksap/nlp/elasticsearch/sudachi/index/SudachiPartOfSpeechFilterFactory.kt
@@ -31,8 +31,8 @@ class SudachiPartOfSpeechFilterFactory(
     indexSettings: IndexSettings?,
     env: Environment?,
     name: String?,
-    settings: Settings?
-) : AbstractTokenFilterFactory(name, settings) {
+    settings: Settings?,
+) : AbstractTokenFilterFactory(name) {
 
   private val stopTags = run {
     val tagList = getWordList(env, settings, "stoptags")

--- a/search/src/main/java/com/worksap/nlp/elasticsearch/sudachi/index/SudachiReadingFormFilterFactory.kt
+++ b/search/src/main/java/com/worksap/nlp/elasticsearch/sudachi/index/SudachiReadingFormFilterFactory.kt
@@ -27,8 +27,8 @@ class SudachiReadingFormFilterFactory(
     indexSettings: IndexSettings?,
     environment: Environment?,
     name: String?,
-    settings: Settings
-) : AbstractTokenFilterFactory(name, settings) {
+    settings: Settings,
+) : AbstractTokenFilterFactory(name) {
   private val useRomaji = settings.getAsBoolean("use_romaji", false)
 
   override fun create(tokenStream: TokenStream): TokenStream {

--- a/search/src/main/java/com/worksap/nlp/elasticsearch/sudachi/index/SudachiSplitFilterFactory.kt
+++ b/search/src/main/java/com/worksap/nlp/elasticsearch/sudachi/index/SudachiSplitFilterFactory.kt
@@ -29,8 +29,8 @@ class SudachiSplitFilterFactory(
     indexSettings: IndexSettings?,
     env: Environment?,
     name: String?,
-    settings: Settings
-) : AbstractTokenFilterFactory(name, settings) {
+    settings: Settings,
+) : AbstractTokenFilterFactory(name) {
 
   private val mode = Mode.fromString(settings.get(Mode.name, null))
   private val splitMode = SplitMode.fromString(settings.get(SplitMode.name, null))
@@ -40,8 +40,8 @@ class SudachiSplitFilterFactory(
   }
 
   companion object {
-    private object Mode :
-        EnumFlag<SudachiSplitFilter.Mode>("mode", SudachiSplitFilter.DEFAULT_MODE)
+    private object Mode : EnumFlag<SudachiSplitFilter.Mode>("mode", SudachiSplitFilter.DEFAULT_MODE)
+
     private object SplitMode : EnumFlag<Tokenizer.SplitMode>("split_mode", Tokenizer.SplitMode.A)
   }
 }

--- a/search/src/main/java/com/worksap/nlp/elasticsearch/sudachi/index/SudachiStopTokenFilterFactory.kt
+++ b/search/src/main/java/com/worksap/nlp/elasticsearch/sudachi/index/SudachiStopTokenFilterFactory.kt
@@ -30,8 +30,8 @@ class SudachiStopTokenFilterFactory(
     indexSettings: IndexSettings?,
     env: Environment?,
     name: String?,
-    settings: Settings
-) : AbstractTokenFilterFactory(name, settings) {
+    settings: Settings,
+) : AbstractTokenFilterFactory(name) {
   private val ignoreCase = settings.getAsBoolean("ignore_case", false)
   private val removeTrailing = settings.getAsBoolean("remove_trailing", true)
   private val stopWords =

--- a/search/src/main/java/com/worksap/nlp/elasticsearch/sudachi/index/SudachiTokenizerFactory.kt
+++ b/search/src/main/java/com/worksap/nlp/elasticsearch/sudachi/index/SudachiTokenizerFactory.kt
@@ -35,14 +35,13 @@ class SudachiTokenizerFactory(
     indexSettings: IndexSettings,
     private val env: Environment,
     name: String,
-    settings: Settings
-) : AbstractTokenizerFactory(indexSettings, settings, name) {
-
+    settings: Settings,
+) : AbstractTokenizerFactory(name) {
   companion object {
     @JvmStatic
     fun maker(
         service: DictionaryService,
-        caches: AnalysisCacheService
+        caches: AnalysisCacheService,
     ): AnalysisProvider<TokenizerFactory> {
       return AnalysisProvider { indexSettings, environment, name, settings ->
         SudachiTokenizerFactory(service, caches, indexSettings, environment, name, settings)

--- a/spi/build.gradle
+++ b/spi/build.gradle
@@ -38,21 +38,8 @@ spotless {
 }
 
 java {
-    def jvmVer = sudachiEs.jvmVersion()
-    def javaVer = jvmVer == 21 ? JavaVersion.VERSION_21 : JavaVersion.VERSION_17
-    sourceCompatibility = javaVer
-    targetCompatibility = javaVer
     withJavadocJar()
     withSourcesJar()
-}
-
-// For OpenSearch 3.0+, we need to tell Gradle that JDK 21+ libraries are compatible
-if (sudachiEs.jvmVersion() >= 21) {
-    configurations.all {
-        attributes {
-            attribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE, sudachiEs.jvmVersion())
-        }
-    }
 }
 
 tasks.named('jar', Jar) {

--- a/subplugin/build.gradle
+++ b/subplugin/build.gradle
@@ -10,28 +10,6 @@ plugins {
 group = 'com.worksap.nlp'
 version = properties["pluginVersion"]
 
-// JVM target is determined by engine version (OpenSearch 3.0+ requires JVM 21)
-def jvmVersion = sudachiEs.jvmVersion()
-def javaVersion = jvmVersion == 21 ? JavaVersion.VERSION_21 : JavaVersion.VERSION_17
-
-java {
-    sourceCompatibility = javaVersion
-    targetCompatibility = javaVersion
-}
-
-tasks.withType(JavaCompile).configureEach {
-    options.release = jvmVersion
-}
-
-// For OpenSearch 3.0+, we need to tell Gradle that JDK 21+ libraries are compatible
-if (jvmVersion >= 21) {
-    configurations.all {
-        attributes {
-            attribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE, jvmVersion)
-        }
-    }
-}
-
 dependencies {
     compileOnly(project(':spi'))
 }

--- a/testlib/build.gradle
+++ b/testlib/build.gradle
@@ -15,37 +15,6 @@ plugins {
 group = 'com.worksap.nlp'
 version = properties["pluginVersion"]
 
-// JVM target is determined by engine version (OpenSearch 3.0+ requires JVM 21)
-def jvmVersion = sudachiEs.jvmVersion()
-def jvmTargetVersion = jvmVersion == 21 ? JvmTarget.JVM_21 : JvmTarget.JVM_17
-def javaVersion = jvmVersion == 21 ? JavaVersion.VERSION_21 : JavaVersion.VERSION_17
-
-java {
-    sourceCompatibility = javaVersion
-    targetCompatibility = javaVersion
-}
-
-tasks.withType(JavaCompile).configureEach {
-    options.release = jvmVersion
-}
-
-compileKotlin {
-    compilerOptions.jvmTarget.set(jvmTargetVersion)
-}
-
-compileTestKotlin {
-    compilerOptions.jvmTarget.set(jvmTargetVersion)
-}
-
-// For OpenSearch 3.0+, we need to tell Gradle that JDK 21+ libraries are compatible
-if (jvmVersion >= 21) {
-    configurations.all {
-        attributes {
-            attribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE, jvmVersion)
-        }
-    }
-}
-
 dependencies {
     implementation(project(':spi'))
     testCompileOnly('junit:junit:4.13.1')


### PR DESCRIPTION
Update code to follow api change in es v9.

- always use jvm version 21.
- remove some args from AbstructTokenFilterFactory constructor.
- re-introduce ext source management plugin for integration test.
  - `SudachiInSearchEngineEnv.kt`
