### PR TITLE
add index and plugin for CompletionFilter on OpenSearch

### DIFF
--- a/search/src/main/java/com/worksap/nlp/elasticsearch/sudachi/index/SudachiCompletionFilterFactory.kt
+++ b/search/src/main/java/com/worksap/nlp/elasticsearch/sudachi/index/SudachiCompletionFilterFactory.kt
@@ -17,7 +17,6 @@
 package com.worksap.nlp.elasticsearch.sudachi.index
 
 import com.worksap.nlp.lucene.sudachi.ja.SudachiCompletionFilter
-import com.worksap.nlp.tools.EnumFlag
 import org.apache.lucene.analysis.TokenStream
 import org.opensearch.common.settings.Settings
 import org.opensearch.env.Environment
@@ -28,17 +27,13 @@ class SudachiCompletionFilterFactory(
     indexSettings: IndexSettings?,
     environment: Environment?,
     name: String?,
-    settings: Settings?,
-) : AbstractTokenFilterFactory(name) {
-
-  private val mode = Mode.fromString(settings?.get(Mode.name, null))
+    settings: Settings
+) : AbstractTokenFilterFactory(indexSettings, name, settings) {
+  private val mode = SudachiCompletionFilter.Mode.valueOf(
+      settings.get("mode", SudachiCompletionFilter.DEFAULT_MODE.name).uppercase()
+  )
 
   override fun create(tokenStream: TokenStream): TokenStream {
     return SudachiCompletionFilter(tokenStream, mode)
-  }
-
-  companion object {
-    private object Mode :
-        EnumFlag<SudachiCompletionFilter.Mode>("mode", SudachiCompletionFilter.DEFAULT_MODE)
   }
 }

--- a/search/src/main/java/com/worksap/nlp/elasticsearch/sudachi/index/SudachiCompletionFilterFactory.kt
+++ b/search/src/main/java/com/worksap/nlp/elasticsearch/sudachi/index/SudachiCompletionFilterFactory.kt
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2022-2026 Works Applications Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.worksap.nlp.elasticsearch.sudachi.index
+
+import com.worksap.nlp.lucene.sudachi.ja.SudachiCompletionFilter
+import com.worksap.nlp.tools.EnumFlag
+import org.apache.lucene.analysis.TokenStream
+import org.opensearch.common.settings.Settings
+import org.opensearch.env.Environment
+import org.opensearch.index.IndexSettings
+import org.opensearch.index.analysis.AbstractTokenFilterFactory
+
+class SudachiCompletionFilterFactory(
+    indexSettings: IndexSettings?,
+    environment: Environment?,
+    name: String?,
+    settings: Settings?,
+) : AbstractTokenFilterFactory(name) {
+
+  private val mode = Mode.fromString(settings?.get(Mode.name, null))
+
+  override fun create(tokenStream: TokenStream): TokenStream {
+    return SudachiCompletionFilter(tokenStream, mode)
+  }
+
+  companion object {
+    private object Mode :
+        EnumFlag<SudachiCompletionFilter.Mode>("mode", SudachiCompletionFilter.DEFAULT_MODE)
+  }
+}

--- a/search/src/main/java/com/worksap/nlp/elasticsearch/sudachi/plugin/AnalysisSudachiPlugin.kt
+++ b/search/src/main/java/com/worksap/nlp/elasticsearch/sudachi/plugin/AnalysisSudachiPlugin.kt
@@ -68,6 +68,7 @@ class AnalysisSudachiPlugin(settings: Settings?) : Plugin(), AnalysisPlugin, Ext
         "sudachi_readingform" to provider(::SudachiReadingFormFilterFactory),
         "sudachi_split" to provider(::SudachiSplitFilterFactory),
         "sudachi_ja_stop" to provider(::SudachiStopTokenFilterFactory),
+        "sudachi_completion" to provider(::SudachiCompletionFilterFactory),
     )
   }
 

--- a/test-scripts/10-init-index.json
+++ b/test-scripts/10-init-index.json
@@ -20,6 +20,14 @@
         "katakana_readingform": {
           "type": "sudachi_readingform",
           "use_romaji": false
+        },
+        "sudachi_completion_index": {
+          "type": "sudachi_completion",
+          "mode": "index"
+        },
+        "sudachi_completion_query": {
+          "type": "sudachi_completion",
+          "mode": "query"
         }
       },
       "analyzer": {
@@ -75,6 +83,20 @@
           "filter": [],
           "type": "custom",
           "tokenizer": "sudachi_a_tokenizer"
+        },
+        "sudachi_completion_index": {
+          "filter": [
+            "sudachi_completion_index"
+          ],
+          "type": "custom",
+          "tokenizer": "sudachi_tokenizer"
+        },
+        "sudachi_completion_query": {
+          "filter": [
+            "sudachi_completion_query"
+          ],
+          "type": "custom",
+          "tokenizer": "sudachi_tokenizer"
         }
       },
       "tokenizer": {


### PR DESCRIPTION
target branch: `os-3`
backport to: `os`

add index and plugin for CompletionFilter

before merge, we also need to:
- merge the filter implementation in lucene. #249 